### PR TITLE
merge 0.11.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 0.11.1 (2024-01-12, TZDB 2023d)
     * Upgrade TZDB to 2023d
         * https://mm.icann.org/pipermail/tz-announce/2023-December/000080.html
         * "Ittoqqortoormiit, Greenland changes time zones on 2024-03-31. Vostok,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 * Unreleased
+    * Upgrade TZDB to 2023d
+        * https://mm.icann.org/pipermail/tz-announce/2023-December/000080.html
+        * "Ittoqqortoormiit, Greenland changes time zones on 2024-03-31. Vostok,
+          Antarctica changed time zones on 2023-12-18. Casey, Antarctica changed
+          time zones five times since 2020. Code and data fixes for Palestine
+          timestamps starting in 2072. A new data file zonenow.tab for
+          timestamps starting now."
 * 0.11.0 (2023-05-31, TZDB 2023c)
     * Update path to ACUnit from https://github.com/bxparks/ACUnit (v0.1) to
       https://github.com/bxparks/acunit (v0.2).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ latter documents.
 
 **Status**: Alpha-level software, not ready for public consumption.
 
-**Version**: 0.11.0 (2023-05-31, TZDB version 2023c)
+**Version**: 0.11.1 (2024-01-12, TZDB 2023d)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=acetimec
-version=0.11.0
+version=0.11.1
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=Date, time, timezone library using the C language

--- a/src/acetimec.h
+++ b/src/acetimec.h
@@ -7,8 +7,8 @@
 #define ACE_TIME_C_H
 
 /* Version format: xxyyzz == "xx.yy.zz" */
-#define ACE_TIME_C_VERSION 1100
-#define ACE_TIME_C_VERSION_STRING "0.11.0"
+#define ACE_TIME_C_VERSION 1101
+#define ACE_TIME_C_VERSION_STRING "0.11.1"
 
 #include "zoneinfo/zone_info.h"
 #include "zoneinfo/zone_info_utils.h"

--- a/src/acetimec/common.h
+++ b/src/acetimec/common.h
@@ -71,6 +71,21 @@ enum {
 
   /** Invalid Unix seconds. */
   kAtcInvalidUnixSeconds = INT64_MIN,
+
+  /**
+   * Minimum year reasonablly supported by the functions in `local_date.h`.
+   * It might be more strict to make this 1, but those functions need to handle
+   * yeare 0 to handle year shifts due to UTC offset.
+   */
+  kAtcMinYear = 0,
+
+  /**
+   * Maxium year reasonablly supported by the functions in `local_date.h`.
+   * It might be more strict to make this 9999 to prevent formatting problems
+   * with more than 4 digits. But those functions need to handle a little bit of
+   * slop to handle year shifts due to UTC offset.
+   */
+  kAtcMaxYear = 10000,
 };
 
 /**

--- a/src/acetimec/zone_processor.c
+++ b/src/acetimec/zone_processor.c
@@ -638,13 +638,13 @@ int8_t atc_processor_init_for_year(
   AtcZoneProcessor *processor,
   int16_t year)
 {
-  if (year == kAtcInvalidYear) return kAtcErrGeneric;
-  if (atc_processor_is_valid_for_year(processor, year)) return kAtcErrOk;
-
-  const AtcZoneContext *context = processor->zone_info->zone_context;
-  if (year < context->start_year - 1 || context->until_year < year) {
+  // Restrict to [1,9999], even though `local_date.h` should be able to handle
+  // [0,10000].
+  if (year <= kAtcMinYear || kAtcMaxYear <= year) {
     return kAtcErrGeneric;
   }
+
+  if (atc_processor_is_valid_for_year(processor, year)) return kAtcErrOk;
 
   processor->epoch_year = atc_get_current_epoch_year();
   processor->year = year;

--- a/src/zonedb/Makefile
+++ b/src/zonedb/Makefile
@@ -16,8 +16,8 @@ all:
 	$(TOOLS)/tzcompiler.sh \
 		--tzrepo $(TZ_REPO) \
 		--tag $(TZ_VERSION) \
-		--action zonedb \
-		--language c \
+		--actions zonedb \
+		--languages c \
 		--scope complete \
 		--db_namespace Atc \
 		--start_year $(START_YEAR) \
@@ -28,8 +28,8 @@ zonedb.json:
 	$(TOOLS)/tzcompiler.sh \
 		--tzrepo $(TZ_REPO) \
 		--tag $(TZ_VERSION) \
-		--action zonedb \
-		--language json \
+		--actions json \
+		--languages c \
 		--scope complete \
 		--start_year $(START_YEAR) \
 		--until_year $(UNTIL_YEAR)

--- a/src/zonedb/Makefile
+++ b/src/zonedb/Makefile
@@ -10,7 +10,7 @@ TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
 TZ_VERSION := 2023c
 START_YEAR := 2000
-UNTIL_YEAR := 10000
+UNTIL_YEAR := 2200
 
 all:
 	$(TOOLS)/tzcompiler.sh \

--- a/src/zonedb/Makefile
+++ b/src/zonedb/Makefile
@@ -18,13 +18,8 @@ all:
 		--tag $(TZ_VERSION) \
 		--action zonedb \
 		--language c \
-		--scope extended \
+		--scope complete \
 		--db_namespace Atc \
-		--offset_granularity 1 \
-		--delta_granularity 60 \
-		--until_at_granularity 1 \
-		--generate_int16_years \
-		--generate_hires \
 		--start_year $(START_YEAR) \
 		--until_year $(UNTIL_YEAR) \
 		--nocompress
@@ -35,8 +30,7 @@ zonedb.json:
 		--tag $(TZ_VERSION) \
 		--action zonedb \
 		--language json \
-		--scope extended \
-		--generate_int16_years \
+		--scope complete \
 		--start_year $(START_YEAR) \
 		--until_year $(UNTIL_YEAR)
 

--- a/src/zonedb/Makefile
+++ b/src/zonedb/Makefile
@@ -8,7 +8,7 @@ zone_registry.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2023c
+TZ_VERSION := 2023d
 START_YEAR := 2000
 UNTIL_YEAR := 2200
 

--- a/src/zonedb/zone_infos.c
+++ b/src/zonedb/zone_infos.c
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000

--- a/src/zonedb/zone_infos.c
+++ b/src/zonedb/zone_infos.c
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedb/zone_infos.c
+++ b/src/zonedb/zone_infos.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 646
+//   Eras: 655
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9690
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 9825
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 597
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37434
+//   TOTAL: 37569
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 12920
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 13100
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 597
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48853
+//   TOTAL: 49033
 //
 // DO NOT EDIT
 
@@ -82,7 +82,7 @@
 // ZoneContext
 //---------------------------------------------------------------------------
 
-static const char kAtcTzDatabaseVersion[] = "2023c";
+static const char kAtcTzDatabaseVersion[] = "2023d";
 
 static const char * const kAtcFragments[] = {
 /*\x00*/ NULL,
@@ -116,8 +116,8 @@ const AtcZoneContext kAtcZoneContext = {
 };
 
 //---------------------------------------------------------------------------
-// Zones: 350
-// Eras: 646
+// Zones: 351
+// Eras: 655
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -5344,16 +5344,29 @@ const AtcZoneInfo kAtcZoneAmerica_North_Dakota_New_Salem  = {
 
 //---------------------------------------------------------------------------
 // Zone name: America/Nuuk
-// Zone Eras: 2
+// Zone Eras: 3
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Nuuk[]  = {
-  //             -3:00    EU    -03/-02    2023 Oct 29  1:00u
+  //             -3:00    EU    -03/-02    2023 Mar 26  1:00u
   {
     &kAtcZonePolicyEU /*zone_policy*/,
     "-03/-02" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
+    0 /*delta_minutes*/,
+    2023 /*until_year*/,
+    3 /*until_month*/,
+    26 /*until_day*/,
+    240 /*until_time_code (3600/15)*/,
+    32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
+  },
+  //             -2:00    -    -02    2023 Oct 29  1:00u
+  {
+    NULL /*zone_policy*/,
+    "-02" /*format*/,
+    -480 /*offset_code (-7200/15)*/,
+    0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
     2023 /*until_year*/,
     10 /*until_month*/,
@@ -5383,7 +5396,7 @@ const AtcZoneInfo kAtcZoneAmerica_Nuuk  = {
   kAtcZoneNameAmerica_Nuuk /*name*/,
   0x9805b5a9 /*zone_id*/,
   &kAtcZoneContext /*zone_context*/,
-  2 /*num_eras*/,
+  3 /*num_eras*/,
   kAtcZoneEraAmerica_Nuuk /*eras*/,
   NULL /*target_info*/,
 };
@@ -6198,16 +6211,29 @@ const AtcZoneInfo kAtcZoneAmerica_Sao_Paulo  = {
 
 //---------------------------------------------------------------------------
 // Zone name: America/Scoresbysund
-// Zone Eras: 1
+// Zone Eras: 2
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Scoresbysund[]  = {
-  //             -1:00    EU    -01/+00
+  //             -1:00    EU    -01/+00 2024 Mar 31
   {
     &kAtcZonePolicyEU /*zone_policy*/,
     "-01/+00" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
+    0 /*delta_minutes*/,
+    2024 /*until_year*/,
+    3 /*until_month*/,
+    31 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -2:00    EU    -02/-01
+  {
+    &kAtcZonePolicyEU /*zone_policy*/,
+    "-02/-01" /*format*/,
+    -480 /*offset_code (-7200/15)*/,
+    0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
     32767 /*until_year*/,
     1 /*until_month*/,
@@ -6224,7 +6250,7 @@ const AtcZoneInfo kAtcZoneAmerica_Scoresbysund  = {
   kAtcZoneNameAmerica_Scoresbysund /*name*/,
   0x123f8d2a /*zone_id*/,
   &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
+  2 /*num_eras*/,
   kAtcZoneEraAmerica_Scoresbysund /*eras*/,
   NULL /*target_info*/,
 };
@@ -6672,7 +6698,7 @@ const AtcZoneInfo kAtcZoneAmerica_Yakutat  = {
 
 //---------------------------------------------------------------------------
 // Zone name: Antarctica/Casey
-// Zone Eras: 12
+// Zone Eras: 17
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
@@ -6819,12 +6845,77 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     4 /*until_time_code (60/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    +11    2021 Mar 14  0:00
   {
     NULL /*zone_policy*/,
     "+11" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
+    0 /*delta_minutes*/,
+    2021 /*until_year*/,
+    3 /*until_month*/,
+    14 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //              8:00    -    +08    2021 Oct  3  0:01
+  {
+    NULL /*zone_policy*/,
+    "+08" /*format*/,
+    1920 /*offset_code (28800/15)*/,
+    0 /*offset_remainder (28800%15)*/,
+    0 /*delta_minutes*/,
+    2021 /*until_year*/,
+    10 /*until_month*/,
+    3 /*until_day*/,
+    4 /*until_time_code (60/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             11:00    -    +11    2022 Mar 13  0:00
+  {
+    NULL /*zone_policy*/,
+    "+11" /*format*/,
+    2640 /*offset_code (39600/15)*/,
+    0 /*offset_remainder (39600%15)*/,
+    0 /*delta_minutes*/,
+    2022 /*until_year*/,
+    3 /*until_month*/,
+    13 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //              8:00    -    +08    2022 Oct  2  0:01
+  {
+    NULL /*zone_policy*/,
+    "+08" /*format*/,
+    1920 /*offset_code (28800/15)*/,
+    0 /*offset_remainder (28800%15)*/,
+    0 /*delta_minutes*/,
+    2022 /*until_year*/,
+    10 /*until_month*/,
+    2 /*until_day*/,
+    4 /*until_time_code (60/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             11:00    -    +11    2023 Mar  9  3:00
+  {
+    NULL /*zone_policy*/,
+    "+11" /*format*/,
+    2640 /*offset_code (39600/15)*/,
+    0 /*offset_remainder (39600%15)*/,
+    0 /*delta_minutes*/,
+    2023 /*until_year*/,
+    3 /*until_month*/,
+    9 /*until_day*/,
+    720 /*until_time_code (10800/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //              8:00    -    +08
+  {
+    NULL /*zone_policy*/,
+    "+08" /*format*/,
+    1920 /*offset_code (28800/15)*/,
+    0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
     32767 /*until_year*/,
     1 /*until_month*/,
@@ -6841,7 +6932,7 @@ const AtcZoneInfo kAtcZoneAntarctica_Casey  = {
   kAtcZoneNameAntarctica_Casey /*name*/,
   0xe2022583 /*zone_id*/,
   &kAtcZoneContext /*zone_context*/,
-  12 /*num_eras*/,
+  17 /*num_eras*/,
   kAtcZoneEraAntarctica_Casey /*eras*/,
   NULL /*target_info*/,
 };
@@ -7158,6 +7249,52 @@ const AtcZoneInfo kAtcZoneAntarctica_Troll  = {
   &kAtcZoneContext /*zone_context*/,
   2 /*num_eras*/,
   kAtcZoneEraAntarctica_Troll /*eras*/,
+  NULL /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Zone name: Antarctica/Vostok
+// Zone Eras: 2
+//---------------------------------------------------------------------------
+
+static const AtcZoneEra kAtcZoneEraAntarctica_Vostok[]  = {
+  //             7:00    -    +07    2023 Dec 18  2:00
+  {
+    NULL /*zone_policy*/,
+    "+07" /*format*/,
+    1680 /*offset_code (25200/15)*/,
+    0 /*offset_remainder (25200%15)*/,
+    0 /*delta_minutes*/,
+    2023 /*until_year*/,
+    12 /*until_month*/,
+    18 /*until_day*/,
+    480 /*until_time_code (7200/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             5:00    -    +05
+  {
+    NULL /*zone_policy*/,
+    "+05" /*format*/,
+    1200 /*offset_code (18000/15)*/,
+    0 /*offset_remainder (18000%15)*/,
+    0 /*delta_minutes*/,
+    32767 /*until_year*/,
+    1 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+
+};
+
+static const char kAtcZoneNameAntarctica_Vostok[]  = "Antarctica/Vostok";
+
+const AtcZoneInfo kAtcZoneAntarctica_Vostok  = {
+  kAtcZoneNameAntarctica_Vostok /*name*/,
+  0x4f966fd4 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  2 /*num_eras*/,
+  kAtcZoneEraAntarctica_Vostok /*eras*/,
   NULL /*target_info*/,
 };
 
@@ -15521,7 +15658,7 @@ const AtcZoneInfo kAtcZoneWET  = {
 
 
 //---------------------------------------------------------------------------
-// Links: 246
+// Links: 245
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -16314,7 +16451,7 @@ const AtcZoneInfo kAtcZoneAmerica_Godthab  = {
   kAtcZoneNameAmerica_Godthab /*name*/,
   0x8f7eba1f /*zone_id*/,
   &kAtcZoneContext /*zone_context*/,
-  2 /*num_eras*/,
+  3 /*num_eras*/,
   kAtcZoneEraAmerica_Nuuk /*eras*/,
   &kAtcZoneAmerica_Nuuk /*target_info*/,
 };
@@ -16827,21 +16964,6 @@ const AtcZoneInfo kAtcZoneAntarctica_Syowa  = {
   1 /*num_eras*/,
   kAtcZoneEraAsia_Riyadh /*eras*/,
   &kAtcZoneAsia_Riyadh /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Link name: Antarctica/Vostok -> Asia/Urumqi
-//---------------------------------------------------------------------------
-
-static const char kAtcZoneNameAntarctica_Vostok[]  = "Antarctica/Vostok";
-
-const AtcZoneInfo kAtcZoneAntarctica_Vostok  = {
-  kAtcZoneNameAntarctica_Vostok /*name*/,
-  0x4f966fd4 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraAsia_Urumqi /*eras*/,
-  &kAtcZoneAsia_Urumqi /*target_info*/,
 };
 
 //---------------------------------------------------------------------------

--- a/src/zonedb/zone_infos.c
+++ b/src/zonedb/zone_infos.c
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7
@@ -101,7 +104,9 @@ static const char* const kAtcLetters[] = {
 
 const AtcZoneContext kAtcZoneContext = {
   2000 /*start_year*/,
-  10000 /*until_year*/,
+  2200 /*until_year*/,
+  2000 /*start_year_accurate*/,
+  32767 /*until_year_accurate*/,
   7 /*max_transitions*/,
   kAtcTzDatabaseVersion /*tz_version*/,
   1 /*num_fragments*/,

--- a/src/zonedb/zone_infos.c
+++ b/src/zonedb/zone_infos.c
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace Atc
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedb/zone_infos.c
+++ b/src/zonedb/zone_infos.c
@@ -41,6 +41,7 @@
 //   Rules: 735
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 8820
 //   Policies: 249
 //   Eras: 9690
@@ -51,9 +52,10 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37418
+//   TOTAL: 37434
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 8820
 //   Policies: 664
 //   Eras: 12920
@@ -64,7 +66,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48829
+//   TOTAL: 48853
 //
 // DO NOT EDIT
 
@@ -72,7 +74,7 @@
 #include "zone_infos.h"
 
 //---------------------------------------------------------------------------
-// ZoneContext (should not be in PROGMEM)
+// ZoneContext
 //---------------------------------------------------------------------------
 
 static const char kAtcTzDatabaseVersion[] = "2023c";

--- a/src/zonedb/zone_infos.h
+++ b/src/zonedb/zone_infos.h
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000

--- a/src/zonedb/zone_infos.h
+++ b/src/zonedb/zone_infos.h
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedb/zone_infos.h
+++ b/src/zonedb/zone_infos.h
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7

--- a/src/zonedb/zone_infos.h
+++ b/src/zonedb/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 646
+//   Eras: 655
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9690
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 9825
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 597
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37434
+//   TOTAL: 37569
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 12920
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 13100
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 597
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48853
+//   TOTAL: 49033
 //
 // DO NOT EDIT
 
@@ -92,8 +92,8 @@ extern "C" {
 extern const AtcZoneContext kAtcZoneContext;
 
 //---------------------------------------------------------------------------
-// Supported zones: 350
-// Supported eras: 646
+// Supported zones: 351
+// Supported eras: 655
 //---------------------------------------------------------------------------
 
 extern const AtcZoneInfo kAtcZoneAfrica_Abidjan; // Africa/Abidjan
@@ -242,6 +242,7 @@ extern const AtcZoneInfo kAtcZoneAntarctica_Mawson; // Antarctica/Mawson
 extern const AtcZoneInfo kAtcZoneAntarctica_Palmer; // Antarctica/Palmer
 extern const AtcZoneInfo kAtcZoneAntarctica_Rothera; // Antarctica/Rothera
 extern const AtcZoneInfo kAtcZoneAntarctica_Troll; // Antarctica/Troll
+extern const AtcZoneInfo kAtcZoneAntarctica_Vostok; // Antarctica/Vostok
 extern const AtcZoneInfo kAtcZoneAsia_Almaty; // Asia/Almaty
 extern const AtcZoneInfo kAtcZoneAsia_Amman; // Asia/Amman
 extern const AtcZoneInfo kAtcZoneAsia_Anadyr; // Asia/Anadyr
@@ -596,6 +597,7 @@ extern const AtcZoneInfo kAtcZoneWET; // WET
 #define kAtcZoneIdAntarctica_Palmer 0x40962f4f /* Antarctica/Palmer */
 #define kAtcZoneIdAntarctica_Rothera 0x0e86d203 /* Antarctica/Rothera */
 #define kAtcZoneIdAntarctica_Troll 0xe33f085b /* Antarctica/Troll */
+#define kAtcZoneIdAntarctica_Vostok 0x4f966fd4 /* Antarctica/Vostok */
 #define kAtcZoneIdAsia_Almaty 0xa61f41fa /* Asia/Almaty */
 #define kAtcZoneIdAsia_Amman 0x148d21bc /* Asia/Amman */
 #define kAtcZoneIdAsia_Anadyr 0xa63cebd1 /* Asia/Anadyr */
@@ -803,7 +805,7 @@ extern const AtcZoneInfo kAtcZoneWET; // WET
 
 
 //---------------------------------------------------------------------------
-// Supported links: 246
+// Supported links: 245
 //---------------------------------------------------------------------------
 
 extern const AtcZoneInfo kAtcZoneAfrica_Accra; // Africa/Accra -> Africa/Abidjan
@@ -893,7 +895,6 @@ extern const AtcZoneInfo kAtcZoneAntarctica_DumontDUrville; // Antarctica/Dumont
 extern const AtcZoneInfo kAtcZoneAntarctica_McMurdo; // Antarctica/McMurdo -> Pacific/Auckland
 extern const AtcZoneInfo kAtcZoneAntarctica_South_Pole; // Antarctica/South_Pole -> Pacific/Auckland
 extern const AtcZoneInfo kAtcZoneAntarctica_Syowa; // Antarctica/Syowa -> Asia/Riyadh
-extern const AtcZoneInfo kAtcZoneAntarctica_Vostok; // Antarctica/Vostok -> Asia/Urumqi
 extern const AtcZoneInfo kAtcZoneArctic_Longyearbyen; // Arctic/Longyearbyen -> Europe/Berlin
 extern const AtcZoneInfo kAtcZoneAsia_Aden; // Asia/Aden -> Asia/Riyadh
 extern const AtcZoneInfo kAtcZoneAsia_Ashkhabad; // Asia/Ashkhabad -> Asia/Ashgabat
@@ -1143,7 +1144,6 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneIdAntarctica_McMurdo 0x6eeb5585 /* Antarctica/McMurdo */
 #define kAtcZoneIdAntarctica_South_Pole 0xcd96b290 /* Antarctica/South_Pole */
 #define kAtcZoneIdAntarctica_Syowa 0xe330c7e1 /* Antarctica/Syowa */
-#define kAtcZoneIdAntarctica_Vostok 0x4f966fd4 /* Antarctica/Vostok */
 #define kAtcZoneIdArctic_Longyearbyen 0xd23e7859 /* Arctic/Longyearbyen */
 #define kAtcZoneIdAsia_Aden 0x1fa7084a /* Asia/Aden */
 #define kAtcZoneIdAsia_Ashkhabad 0x15454f09 /* Asia/Ashkhabad */
@@ -1439,7 +1439,7 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneBufSizeAmerica_Santiago 5  /* America/Santiago in 2002 */
 #define kAtcZoneBufSizeAmerica_Santo_Domingo 4  /* America/Santo_Domingo in 2000 */
 #define kAtcZoneBufSizeAmerica_Sao_Paulo 6  /* America/Sao_Paulo in 2003 */
-#define kAtcZoneBufSizeAmerica_Scoresbysund 5  /* America/Scoresbysund in 1983 */
+#define kAtcZoneBufSizeAmerica_Scoresbysund 6  /* America/Scoresbysund in 2024 */
 #define kAtcZoneBufSizeAmerica_Sitka 6  /* America/Sitka in 2008 */
 #define kAtcZoneBufSizeAmerica_St_Johns 6  /* America/St_Johns in 2008 */
 #define kAtcZoneBufSizeAmerica_Swift_Current 1  /* America/Swift_Current in 1949 */
@@ -1458,6 +1458,7 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneBufSizeAntarctica_Palmer 5  /* Antarctica/Palmer in 2002 */
 #define kAtcZoneBufSizeAntarctica_Rothera 1  /* Antarctica/Rothera in 1949 */
 #define kAtcZoneBufSizeAntarctica_Troll 6  /* Antarctica/Troll in 2005 */
+#define kAtcZoneBufSizeAntarctica_Vostok 2  /* Antarctica/Vostok in 2023 */
 #define kAtcZoneBufSizeAsia_Almaty 5  /* Asia/Almaty in 1987 */
 #define kAtcZoneBufSizeAsia_Amman 6  /* Asia/Amman in 2014 */
 #define kAtcZoneBufSizeAsia_Anadyr 5  /* Asia/Anadyr in 1987 */

--- a/src/zonedb/zone_infos.h
+++ b/src/zonedb/zone_infos.h
@@ -41,6 +41,7 @@
 //   Rules: 735
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 8820
 //   Policies: 249
 //   Eras: 9690
@@ -51,9 +52,10 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37418
+//   TOTAL: 37434
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 8820
 //   Policies: 664
 //   Eras: 12920
@@ -64,7 +66,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48829
+//   TOTAL: 48853
 //
 // DO NOT EDIT
 

--- a/src/zonedb/zone_infos.h
+++ b/src/zonedb/zone_infos.h
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace Atc
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedb/zone_policies.c
+++ b/src/zonedb/zone_policies.c
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000

--- a/src/zonedb/zone_policies.c
+++ b/src/zonedb/zone_policies.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 646
+//   Eras: 655
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9690
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 9825
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 597
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37434
+//   TOTAL: 37569
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 12920
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 13100
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 597
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48853
+//   TOTAL: 49033
 //
 // DO NOT EDIT
 
@@ -7896,6 +7896,18 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     60 /*delta_minutes*/,
     7 /*letterIndex ("S")*/,
   },
+  // Rule Palestine    2072    max    -    Oct    Sat<=30    2:00    0    -
+  {
+    2072 /*from_year*/,
+    32766 /*to_year*/,
+    10 /*in_month*/,
+    6 /*on_day_of_week*/,
+    -30 /*on_day_of_month*/,
+    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
+    480 /*at_time_code (7200/15)*/,
+    0 /*delta_minutes*/,
+    0 /*letterIndex ("")*/,
+  },
   // Rule Palestine    2073    only    -    Sep     2    2:00    0    -
   {
     2073 /*from_year*/,
@@ -7967,18 +7979,6 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     7 /*letterIndex ("S")*/,
-  },
-  // Rule Palestine    2075    max    -    Oct    Sat<=30    2:00    0    -
-  {
-    2075 /*from_year*/,
-    32766 /*to_year*/,
-    10 /*in_month*/,
-    6 /*on_day_of_week*/,
-    -30 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    0 /*delta_minutes*/,
-    0 /*letterIndex ("")*/,
   },
   // Rule Palestine    2076    only    -    Jul    25    2:00    0    -
   {

--- a/src/zonedb/zone_policies.c
+++ b/src/zonedb/zone_policies.c
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedb/zone_policies.c
+++ b/src/zonedb/zone_policies.c
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7

--- a/src/zonedb/zone_policies.c
+++ b/src/zonedb/zone_policies.c
@@ -41,6 +41,7 @@
 //   Rules: 735
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 8820
 //   Policies: 249
 //   Eras: 9690
@@ -51,9 +52,10 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37418
+//   TOTAL: 37434
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 8820
 //   Policies: 664
 //   Eras: 12920
@@ -64,7 +66,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48829
+//   TOTAL: 48853
 //
 // DO NOT EDIT
 

--- a/src/zonedb/zone_policies.c
+++ b/src/zonedb/zone_policies.c
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace Atc
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedb/zone_policies.h
+++ b/src/zonedb/zone_policies.h
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000

--- a/src/zonedb/zone_policies.h
+++ b/src/zonedb/zone_policies.h
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedb/zone_policies.h
+++ b/src/zonedb/zone_policies.h
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7

--- a/src/zonedb/zone_policies.h
+++ b/src/zonedb/zone_policies.h
@@ -41,6 +41,7 @@
 //   Rules: 735
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 8820
 //   Policies: 249
 //   Eras: 9690
@@ -51,9 +52,10 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37418
+//   TOTAL: 37434
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 8820
 //   Policies: 664
 //   Eras: 12920
@@ -64,7 +66,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48829
+//   TOTAL: 48853
 //
 // DO NOT EDIT
 
@@ -79,7 +81,6 @@ extern "C" {
 
 //---------------------------------------------------------------------------
 // Supported policies: 83
-// Supported rules: 735
 //---------------------------------------------------------------------------
 
 extern const AtcZonePolicy kAtcZonePolicyAN;

--- a/src/zonedb/zone_policies.h
+++ b/src/zonedb/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 646
+//   Eras: 655
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9690
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 9825
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 597
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37434
+//   TOTAL: 37569
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 12920
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 13100
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 597
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48853
+//   TOTAL: 49033
 //
 // DO NOT EDIT
 

--- a/src/zonedb/zone_policies.h
+++ b/src/zonedb/zone_policies.h
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace Atc
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedb/zone_registry.c
+++ b/src/zonedb/zone_registry.c
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000

--- a/src/zonedb/zone_registry.c
+++ b/src/zonedb/zone_registry.c
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedb/zone_registry.c
+++ b/src/zonedb/zone_registry.c
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7

--- a/src/zonedb/zone_registry.c
+++ b/src/zonedb/zone_registry.c
@@ -41,6 +41,7 @@
 //   Rules: 735
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 8820
 //   Policies: 249
 //   Eras: 9690
@@ -51,9 +52,10 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37418
+//   TOTAL: 37434
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 8820
 //   Policies: 664
 //   Eras: 12920
@@ -64,7 +66,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48829
+//   TOTAL: 48853
 //
 // DO NOT EDIT
 

--- a/src/zonedb/zone_registry.c
+++ b/src/zonedb/zone_registry.c
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace Atc
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedb/zone_registry.c
+++ b/src/zonedb/zone_registry.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 646
+//   Eras: 655
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9690
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 9825
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 597
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37434
+//   TOTAL: 37569
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 12920
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 13100
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 597
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48853
+//   TOTAL: 49033
 //
 // DO NOT EDIT
 
@@ -81,7 +81,7 @@
 //---------------------------------------------------------------------------
 // Zone Info registry. Sorted by zoneId.
 //---------------------------------------------------------------------------
-const AtcZoneInfo * const kAtcZoneRegistry[350]  = {
+const AtcZoneInfo * const kAtcZoneRegistry[351]  = {
   &kAtcZoneAmerica_St_Johns, // 0x04b14e6e, America/St_Johns
   &kAtcZoneAmerica_North_Dakota_New_Salem, // 0x04f9958e, America/North_Dakota/New_Salem
   &kAtcZoneAsia_Jakarta, // 0x0506ab50, Asia/Jakarta
@@ -184,6 +184,7 @@ const AtcZoneInfo * const kAtcZoneRegistry[350]  = {
   &kAtcZoneAsia_Nicosia, // 0x4b0fcf78, Asia/Nicosia
   &kAtcZoneAmerica_Chicago, // 0x4b92b5d4, America/Chicago
   &kAtcZoneAustralia_Sydney, // 0x4d1e9776, Australia/Sydney
+  &kAtcZoneAntarctica_Vostok, // 0x4f966fd4, Antarctica/Vostok
   &kAtcZoneAustralia_Brisbane, // 0x4fedc9c0, Australia/Brisbane
   &kAtcZoneAmerica_Asuncion, // 0x50ec79a6, America/Asuncion
   &kAtcZoneAsia_Karachi, // 0x527f5245, Asia/Karachi
@@ -610,7 +611,7 @@ const AtcZoneInfo * const kAtcZoneAndLinkRegistry[596]  = {
   &kAtcZoneAustralia_Sydney, // 0x4d1e9776, Australia/Sydney
   &kAtcZoneNZ_CHAT, // 0x4d42afda, NZ-CHAT -> Pacific/Chatham
   &kAtcZoneUS_Arizona, // 0x4ec52670, US/Arizona -> America/Phoenix
-  &kAtcZoneAntarctica_Vostok, // 0x4f966fd4, Antarctica/Vostok -> Asia/Urumqi
+  &kAtcZoneAntarctica_Vostok, // 0x4f966fd4, Antarctica/Vostok
   &kAtcZoneUS_Aleutian, // 0x4fe013ef, US/Aleutian -> America/Adak
   &kAtcZoneAustralia_Brisbane, // 0x4fedc9c0, Australia/Brisbane
   &kAtcZoneAmerica_Catamarca, // 0x5036e963, America/Catamarca -> America/Argentina/Catamarca

--- a/src/zonedb/zone_registry.h
+++ b/src/zonedb/zone_registry.h
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000

--- a/src/zonedb/zone_registry.h
+++ b/src/zonedb/zone_registry.h
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedb/zone_registry.h
+++ b/src/zonedb/zone_registry.h
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace Atc
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1950,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1950,2090]
 // Max Buffer Size: 7

--- a/src/zonedb/zone_registry.h
+++ b/src/zonedb/zone_registry.h
@@ -41,6 +41,7 @@
 //   Rules: 735
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 8820
 //   Policies: 249
 //   Eras: 9690
@@ -51,9 +52,10 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37418
+//   TOTAL: 37434
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 8820
 //   Policies: 664
 //   Eras: 12920
@@ -64,7 +66,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48829
+//   TOTAL: 48853
 //
 // DO NOT EDIT
 

--- a/src/zonedb/zone_registry.h
+++ b/src/zonedb/zone_registry.h
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace Atc
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedb/zone_registry.h
+++ b/src/zonedb/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 646
+//   Eras: 655
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9690
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 9825
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 597
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37434
+//   TOTAL: 37569
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 12920
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 13100
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 597
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 48853
+//   TOTAL: 49033
 //
 // DO NOT EDIT
 
@@ -85,8 +85,8 @@ extern "C" {
 #endif
 
 // Zones
-#define kAtcZoneRegistrySize 350
-extern const AtcZoneInfo * const kAtcZoneRegistry[350];
+#define kAtcZoneRegistrySize 351
+extern const AtcZoneInfo * const kAtcZoneRegistry[351];
 
 // Zones and Links
 #define kAtcZoneAndLinkRegistrySize 596

--- a/src/zonedball/Makefile
+++ b/src/zonedball/Makefile
@@ -8,7 +8,7 @@ zone_registry.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2023c
+TZ_VERSION := 2023d
 START_YEAR := 1800
 UNTIL_YEAR := 2200
 

--- a/src/zonedball/Makefile
+++ b/src/zonedball/Makefile
@@ -18,13 +18,8 @@ all:
 		--tag $(TZ_VERSION) \
 		--action zonedb \
 		--language c \
-		--scope extended \
+		--scope complete \
 		--db_namespace AtcAll \
-		--offset_granularity 1 \
-		--delta_granularity 60 \
-		--until_at_granularity 1 \
-		--generate_int16_years \
-		--generate_hires \
 		--start_year $(START_YEAR) \
 		--until_year $(UNTIL_YEAR) \
 		--nocompress
@@ -35,8 +30,7 @@ zonedb.json:
 		--tag $(TZ_VERSION) \
 		--action zonedb \
 		--language json \
-		--scope extended \
-		--generate_int16_years \
+		--scope complete \
 		--start_year $(START_YEAR) \
 		--until_year $(UNTIL_YEAR)
 

--- a/src/zonedball/Makefile
+++ b/src/zonedball/Makefile
@@ -16,8 +16,8 @@ all:
 	$(TOOLS)/tzcompiler.sh \
 		--tzrepo $(TZ_REPO) \
 		--tag $(TZ_VERSION) \
-		--action zonedb \
-		--language c \
+		--actions zonedb \
+		--languages c \
 		--scope complete \
 		--db_namespace AtcAll \
 		--start_year $(START_YEAR) \
@@ -28,8 +28,8 @@ zonedb.json:
 	$(TOOLS)/tzcompiler.sh \
 		--tzrepo $(TZ_REPO) \
 		--tag $(TZ_VERSION) \
-		--action zonedb \
-		--language json \
+		--actions json \
+		--languages c \
 		--scope complete \
 		--start_year $(START_YEAR) \
 		--until_year $(UNTIL_YEAR)

--- a/src/zonedball/Makefile
+++ b/src/zonedball/Makefile
@@ -10,7 +10,7 @@ TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
 TZ_VERSION := 2023c
 START_YEAR := 1800
-UNTIL_YEAR := 10000
+UNTIL_YEAR := 2200
 
 all:
 	$(TOOLS)/tzcompiler.sh \

--- a/src/zonedball/zone_infos.c
+++ b/src/zonedball/zone_infos.c
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
+// Lower/Upper Truncated: [False, False]
+//
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8
 //

--- a/src/zonedball/zone_infos.c
+++ b/src/zonedball/zone_infos.c
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcAll
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 1800
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedball/zone_infos.c
+++ b/src/zonedball/zone_infos.c
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800

--- a/src/zonedball/zone_infos.c
+++ b/src/zonedball/zone_infos.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1949
+//   Eras: 1961
 //   Policies: 134
 //   Rules: 2238
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 26856
 //   Policies: 402
-//   Eras: 29235
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 29415
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 1032
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75717
+//   TOTAL: 75897
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 26856
 //   Policies: 1072
-//   Eras: 38980
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 39220
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 1032
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93944
+//   TOTAL: 94184
 //
 // DO NOT EDIT
 
@@ -82,7 +82,7 @@
 // ZoneContext
 //---------------------------------------------------------------------------
 
-static const char kAtcTzDatabaseVersion[] = "2023c";
+static const char kAtcTzDatabaseVersion[] = "2023d";
 
 static const char * const kAtcFragments[] = {
 /*\x00*/ NULL,
@@ -135,8 +135,8 @@ const AtcZoneContext kAtcAllZoneContext = {
 };
 
 //---------------------------------------------------------------------------
-// Zones: 350
-// Eras: 1949
+// Zones: 351
+// Eras: 1961
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -11356,7 +11356,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_North_Dakota_New_Salem  = {
 
 //---------------------------------------------------------------------------
 // Zone name: America/Nuuk
-// Zone Eras: 4
+// Zone Eras: 5
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Nuuk[]  = {
@@ -11386,12 +11386,25 @@ static const AtcZoneEra kAtcZoneEraAmerica_Nuuk[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    EU    -03/-02    2023 Oct 29  1:00u
+  //             -3:00    EU    -03/-02    2023 Mar 26  1:00u
   {
     &kAtcAllZonePolicyEU /*zone_policy*/,
     "-03/-02" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
+    0 /*delta_minutes*/,
+    2023 /*until_year*/,
+    3 /*until_month*/,
+    26 /*until_day*/,
+    240 /*until_time_code (3600/15)*/,
+    32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
+  },
+  //             -2:00    -    -02    2023 Oct 29  1:00u
+  {
+    NULL /*zone_policy*/,
+    "-02" /*format*/,
+    -480 /*offset_code (-7200/15)*/,
+    0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
     2023 /*until_year*/,
     10 /*until_month*/,
@@ -11421,7 +11434,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Nuuk  = {
   kAtcZoneNameAmerica_Nuuk /*name*/,
   0x9805b5a9 /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  4 /*num_eras*/,
+  5 /*num_eras*/,
   kAtcZoneEraAmerica_Nuuk /*eras*/,
   NULL /*target_info*/,
 };
@@ -13107,7 +13120,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Sao_Paulo  = {
 
 //---------------------------------------------------------------------------
 // Zone name: America/Scoresbysund
-// Zone Eras: 4
+// Zone Eras: 5
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Scoresbysund[]  = {
@@ -13150,12 +13163,25 @@ static const AtcZoneEra kAtcZoneEraAmerica_Scoresbysund[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -1:00    EU    -01/+00
+  //             -1:00    EU    -01/+00 2024 Mar 31
   {
     &kAtcAllZonePolicyEU /*zone_policy*/,
     "-01/+00" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
+    0 /*delta_minutes*/,
+    2024 /*until_year*/,
+    3 /*until_month*/,
+    31 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -2:00    EU    -02/-01
+  {
+    &kAtcAllZonePolicyEU /*zone_policy*/,
+    "-02/-01" /*format*/,
+    -480 /*offset_code (-7200/15)*/,
+    0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
     32767 /*until_year*/,
     1 /*until_month*/,
@@ -13172,7 +13198,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Scoresbysund  = {
   kAtcZoneNameAmerica_Scoresbysund /*name*/,
   0x123f8d2a /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  4 /*num_eras*/,
+  5 /*num_eras*/,
   kAtcZoneEraAmerica_Scoresbysund /*eras*/,
   NULL /*target_info*/,
 };
@@ -14296,7 +14322,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Yakutat  = {
 
 //---------------------------------------------------------------------------
 // Zone name: Antarctica/Casey
-// Zone Eras: 13
+// Zone Eras: 18
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
@@ -14456,12 +14482,77 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     4 /*until_time_code (60/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    +11    2021 Mar 14  0:00
   {
     NULL /*zone_policy*/,
     "+11" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
+    0 /*delta_minutes*/,
+    2021 /*until_year*/,
+    3 /*until_month*/,
+    14 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //              8:00    -    +08    2021 Oct  3  0:01
+  {
+    NULL /*zone_policy*/,
+    "+08" /*format*/,
+    1920 /*offset_code (28800/15)*/,
+    0 /*offset_remainder (28800%15)*/,
+    0 /*delta_minutes*/,
+    2021 /*until_year*/,
+    10 /*until_month*/,
+    3 /*until_day*/,
+    4 /*until_time_code (60/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             11:00    -    +11    2022 Mar 13  0:00
+  {
+    NULL /*zone_policy*/,
+    "+11" /*format*/,
+    2640 /*offset_code (39600/15)*/,
+    0 /*offset_remainder (39600%15)*/,
+    0 /*delta_minutes*/,
+    2022 /*until_year*/,
+    3 /*until_month*/,
+    13 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //              8:00    -    +08    2022 Oct  2  0:01
+  {
+    NULL /*zone_policy*/,
+    "+08" /*format*/,
+    1920 /*offset_code (28800/15)*/,
+    0 /*offset_remainder (28800%15)*/,
+    0 /*delta_minutes*/,
+    2022 /*until_year*/,
+    10 /*until_month*/,
+    2 /*until_day*/,
+    4 /*until_time_code (60/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             11:00    -    +11    2023 Mar  9  3:00
+  {
+    NULL /*zone_policy*/,
+    "+11" /*format*/,
+    2640 /*offset_code (39600/15)*/,
+    0 /*offset_remainder (39600%15)*/,
+    0 /*delta_minutes*/,
+    2023 /*until_year*/,
+    3 /*until_month*/,
+    9 /*until_day*/,
+    720 /*until_time_code (10800/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //              8:00    -    +08
+  {
+    NULL /*zone_policy*/,
+    "+08" /*format*/,
+    1920 /*offset_code (28800/15)*/,
+    0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
     32767 /*until_year*/,
     1 /*until_month*/,
@@ -14478,7 +14569,7 @@ const AtcZoneInfo kAtcAllZoneAntarctica_Casey  = {
   kAtcZoneNameAntarctica_Casey /*name*/,
   0xe2022583 /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  13 /*num_eras*/,
+  18 /*num_eras*/,
   kAtcZoneEraAntarctica_Casey /*eras*/,
   NULL /*target_info*/,
 };
@@ -14977,6 +15068,91 @@ const AtcZoneInfo kAtcAllZoneAntarctica_Troll  = {
   &kAtcAllZoneContext /*zone_context*/,
   2 /*num_eras*/,
   kAtcZoneEraAntarctica_Troll /*eras*/,
+  NULL /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Zone name: Antarctica/Vostok
+// Zone Eras: 5
+//---------------------------------------------------------------------------
+
+static const AtcZoneEra kAtcZoneEraAntarctica_Vostok[]  = {
+  // 0 - -00 1957 Dec 16
+  {
+    NULL /*zone_policy*/,
+    "-00" /*format*/,
+    0 /*offset_code (0/15)*/,
+    0 /*offset_remainder (0%15)*/,
+    0 /*delta_minutes*/,
+    1957 /*until_year*/,
+    12 /*until_month*/,
+    16 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             7:00    -    +07    1994 Feb
+  {
+    NULL /*zone_policy*/,
+    "+07" /*format*/,
+    1680 /*offset_code (25200/15)*/,
+    0 /*offset_remainder (25200%15)*/,
+    0 /*delta_minutes*/,
+    1994 /*until_year*/,
+    2 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             0    -    -00    1994 Nov
+  {
+    NULL /*zone_policy*/,
+    "-00" /*format*/,
+    0 /*offset_code (0/15)*/,
+    0 /*offset_remainder (0%15)*/,
+    0 /*delta_minutes*/,
+    1994 /*until_year*/,
+    11 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             7:00    -    +07    2023 Dec 18  2:00
+  {
+    NULL /*zone_policy*/,
+    "+07" /*format*/,
+    1680 /*offset_code (25200/15)*/,
+    0 /*offset_remainder (25200%15)*/,
+    0 /*delta_minutes*/,
+    2023 /*until_year*/,
+    12 /*until_month*/,
+    18 /*until_day*/,
+    480 /*until_time_code (7200/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             5:00    -    +05
+  {
+    NULL /*zone_policy*/,
+    "+05" /*format*/,
+    1200 /*offset_code (18000/15)*/,
+    0 /*offset_remainder (18000%15)*/,
+    0 /*delta_minutes*/,
+    32767 /*until_year*/,
+    1 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+
+};
+
+static const char kAtcZoneNameAntarctica_Vostok[]  = "Antarctica/Vostok";
+
+const AtcZoneInfo kAtcAllZoneAntarctica_Vostok  = {
+  kAtcZoneNameAntarctica_Vostok /*name*/,
+  0x4f966fd4 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  5 /*num_eras*/,
+  kAtcZoneEraAntarctica_Vostok /*eras*/,
   NULL /*target_info*/,
 };
 
@@ -32479,7 +32655,7 @@ const AtcZoneInfo kAtcAllZoneWET  = {
 
 
 //---------------------------------------------------------------------------
-// Links: 246
+// Links: 245
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -33272,7 +33448,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Godthab  = {
   kAtcZoneNameAmerica_Godthab /*name*/,
   0x8f7eba1f /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  4 /*num_eras*/,
+  5 /*num_eras*/,
   kAtcZoneEraAmerica_Nuuk /*eras*/,
   &kAtcAllZoneAmerica_Nuuk /*target_info*/,
 };
@@ -33785,21 +33961,6 @@ const AtcZoneInfo kAtcAllZoneAntarctica_Syowa  = {
   2 /*num_eras*/,
   kAtcZoneEraAsia_Riyadh /*eras*/,
   &kAtcAllZoneAsia_Riyadh /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Link name: Antarctica/Vostok -> Asia/Urumqi
-//---------------------------------------------------------------------------
-
-static const char kAtcZoneNameAntarctica_Vostok[]  = "Antarctica/Vostok";
-
-const AtcZoneInfo kAtcAllZoneAntarctica_Vostok  = {
-  kAtcZoneNameAntarctica_Vostok /*name*/,
-  0x4f966fd4 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  2 /*num_eras*/,
-  kAtcZoneEraAsia_Urumqi /*eras*/,
-  &kAtcAllZoneAsia_Urumqi /*target_info*/,
 };
 
 //---------------------------------------------------------------------------

--- a/src/zonedball/zone_infos.c
+++ b/src/zonedball/zone_infos.c
@@ -41,6 +41,7 @@
 //   Rules: 2238
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 26856
 //   Policies: 402
 //   Eras: 29235
@@ -51,9 +52,10 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75701
+//   TOTAL: 75717
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 26856
 //   Policies: 1072
 //   Eras: 38980
@@ -64,7 +66,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93920
+//   TOTAL: 93944
 //
 // DO NOT EDIT
 
@@ -72,7 +74,7 @@
 #include "zone_infos.h"
 
 //---------------------------------------------------------------------------
-// ZoneContext (should not be in PROGMEM)
+// ZoneContext
 //---------------------------------------------------------------------------
 
 static const char kAtcTzDatabaseVersion[] = "2023c";

--- a/src/zonedball/zone_infos.c
+++ b/src/zonedball/zone_infos.c
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [1800,2200]
+// Accurate Years: [-32767,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
-// Lower/Upper Truncated: [False, False]
+// Lower/Upper Truncated: [False,False]
 //
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8
@@ -120,7 +123,9 @@ static const char* const kAtcLetters[] = {
 
 const AtcZoneContext kAtcAllZoneContext = {
   1800 /*start_year*/,
-  10000 /*until_year*/,
+  2200 /*until_year*/,
+  -32767 /*start_year_accurate*/,
+  32767 /*until_year_accurate*/,
   8 /*max_transitions*/,
   kAtcTzDatabaseVersion /*tz_version*/,
   1 /*num_fragments*/,

--- a/src/zonedball/zone_infos.h
+++ b/src/zonedball/zone_infos.h
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
+// Lower/Upper Truncated: [False, False]
+//
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8
 //

--- a/src/zonedball/zone_infos.h
+++ b/src/zonedball/zone_infos.h
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [1800,2200]
+// Accurate Years: [-32767,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
-// Lower/Upper Truncated: [False, False]
+// Lower/Upper Truncated: [False,False]
 //
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8

--- a/src/zonedball/zone_infos.h
+++ b/src/zonedball/zone_infos.h
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcAll
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 1800
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedball/zone_infos.h
+++ b/src/zonedball/zone_infos.h
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800

--- a/src/zonedball/zone_infos.h
+++ b/src/zonedball/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1949
+//   Eras: 1961
 //   Policies: 134
 //   Rules: 2238
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 26856
 //   Policies: 402
-//   Eras: 29235
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 29415
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 1032
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75717
+//   TOTAL: 75897
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 26856
 //   Policies: 1072
-//   Eras: 38980
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 39220
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 1032
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93944
+//   TOTAL: 94184
 //
 // DO NOT EDIT
 
@@ -92,8 +92,8 @@ extern "C" {
 extern const AtcZoneContext kAtcAllZoneContext;
 
 //---------------------------------------------------------------------------
-// Supported zones: 350
-// Supported eras: 1949
+// Supported zones: 351
+// Supported eras: 1961
 //---------------------------------------------------------------------------
 
 extern const AtcZoneInfo kAtcAllZoneAfrica_Abidjan; // Africa/Abidjan
@@ -242,6 +242,7 @@ extern const AtcZoneInfo kAtcAllZoneAntarctica_Mawson; // Antarctica/Mawson
 extern const AtcZoneInfo kAtcAllZoneAntarctica_Palmer; // Antarctica/Palmer
 extern const AtcZoneInfo kAtcAllZoneAntarctica_Rothera; // Antarctica/Rothera
 extern const AtcZoneInfo kAtcAllZoneAntarctica_Troll; // Antarctica/Troll
+extern const AtcZoneInfo kAtcAllZoneAntarctica_Vostok; // Antarctica/Vostok
 extern const AtcZoneInfo kAtcAllZoneAsia_Almaty; // Asia/Almaty
 extern const AtcZoneInfo kAtcAllZoneAsia_Amman; // Asia/Amman
 extern const AtcZoneInfo kAtcAllZoneAsia_Anadyr; // Asia/Anadyr
@@ -596,6 +597,7 @@ extern const AtcZoneInfo kAtcAllZoneWET; // WET
 #define kAtcAllZoneIdAntarctica_Palmer 0x40962f4f /* Antarctica/Palmer */
 #define kAtcAllZoneIdAntarctica_Rothera 0x0e86d203 /* Antarctica/Rothera */
 #define kAtcAllZoneIdAntarctica_Troll 0xe33f085b /* Antarctica/Troll */
+#define kAtcAllZoneIdAntarctica_Vostok 0x4f966fd4 /* Antarctica/Vostok */
 #define kAtcAllZoneIdAsia_Almaty 0xa61f41fa /* Asia/Almaty */
 #define kAtcAllZoneIdAsia_Amman 0x148d21bc /* Asia/Amman */
 #define kAtcAllZoneIdAsia_Anadyr 0xa63cebd1 /* Asia/Anadyr */
@@ -803,7 +805,7 @@ extern const AtcZoneInfo kAtcAllZoneWET; // WET
 
 
 //---------------------------------------------------------------------------
-// Supported links: 246
+// Supported links: 245
 //---------------------------------------------------------------------------
 
 extern const AtcZoneInfo kAtcAllZoneAfrica_Accra; // Africa/Accra -> Africa/Abidjan
@@ -893,7 +895,6 @@ extern const AtcZoneInfo kAtcAllZoneAntarctica_DumontDUrville; // Antarctica/Dum
 extern const AtcZoneInfo kAtcAllZoneAntarctica_McMurdo; // Antarctica/McMurdo -> Pacific/Auckland
 extern const AtcZoneInfo kAtcAllZoneAntarctica_South_Pole; // Antarctica/South_Pole -> Pacific/Auckland
 extern const AtcZoneInfo kAtcAllZoneAntarctica_Syowa; // Antarctica/Syowa -> Asia/Riyadh
-extern const AtcZoneInfo kAtcAllZoneAntarctica_Vostok; // Antarctica/Vostok -> Asia/Urumqi
 extern const AtcZoneInfo kAtcAllZoneArctic_Longyearbyen; // Arctic/Longyearbyen -> Europe/Berlin
 extern const AtcZoneInfo kAtcAllZoneAsia_Aden; // Asia/Aden -> Asia/Riyadh
 extern const AtcZoneInfo kAtcAllZoneAsia_Ashkhabad; // Asia/Ashkhabad -> Asia/Ashgabat
@@ -1143,7 +1144,6 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneIdAntarctica_McMurdo 0x6eeb5585 /* Antarctica/McMurdo */
 #define kAtcAllZoneIdAntarctica_South_Pole 0xcd96b290 /* Antarctica/South_Pole */
 #define kAtcAllZoneIdAntarctica_Syowa 0xe330c7e1 /* Antarctica/Syowa */
-#define kAtcAllZoneIdAntarctica_Vostok 0x4f966fd4 /* Antarctica/Vostok */
 #define kAtcAllZoneIdArctic_Longyearbyen 0xd23e7859 /* Arctic/Longyearbyen */
 #define kAtcAllZoneIdAsia_Aden 0x1fa7084a /* Asia/Aden */
 #define kAtcAllZoneIdAsia_Ashkhabad 0x15454f09 /* Asia/Ashkhabad */
@@ -1439,7 +1439,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneBufSizeAmerica_Santiago 6  /* America/Santiago in 1969 */
 #define kAtcAllZoneBufSizeAmerica_Santo_Domingo 4  /* America/Santo_Domingo in 1970 */
 #define kAtcAllZoneBufSizeAmerica_Sao_Paulo 6  /* America/Sao_Paulo in 1964 */
-#define kAtcAllZoneBufSizeAmerica_Scoresbysund 5  /* America/Scoresbysund in 1980 */
+#define kAtcAllZoneBufSizeAmerica_Scoresbysund 6  /* America/Scoresbysund in 2024 */
 #define kAtcAllZoneBufSizeAmerica_Sitka 6  /* America/Sitka in 1983 */
 #define kAtcAllZoneBufSizeAmerica_St_Johns 6  /* America/St_Johns in 1918 */
 #define kAtcAllZoneBufSizeAmerica_Swift_Current 5  /* America/Swift_Current in 1946 */
@@ -1458,6 +1458,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneBufSizeAntarctica_Palmer 6  /* Antarctica/Palmer in 1965 */
 #define kAtcAllZoneBufSizeAntarctica_Rothera 2  /* Antarctica/Rothera in 1976 */
 #define kAtcAllZoneBufSizeAntarctica_Troll 6  /* Antarctica/Troll in 2005 */
+#define kAtcAllZoneBufSizeAntarctica_Vostok 3  /* Antarctica/Vostok in 1994 */
 #define kAtcAllZoneBufSizeAsia_Almaty 6  /* Asia/Almaty in 1991 */
 #define kAtcAllZoneBufSizeAsia_Amman 6  /* Asia/Amman in 2014 */
 #define kAtcAllZoneBufSizeAsia_Anadyr 6  /* Asia/Anadyr in 1991 */

--- a/src/zonedball/zone_infos.h
+++ b/src/zonedball/zone_infos.h
@@ -41,6 +41,7 @@
 //   Rules: 2238
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 26856
 //   Policies: 402
 //   Eras: 29235
@@ -51,9 +52,10 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75701
+//   TOTAL: 75717
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 26856
 //   Policies: 1072
 //   Eras: 38980
@@ -64,7 +66,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93920
+//   TOTAL: 93944
 //
 // DO NOT EDIT
 

--- a/src/zonedball/zone_policies.c
+++ b/src/zonedball/zone_policies.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1949
+//   Eras: 1961
 //   Policies: 134
 //   Rules: 2238
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 26856
 //   Policies: 402
-//   Eras: 29235
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 29415
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 1032
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75717
+//   TOTAL: 75897
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 26856
 //   Policies: 1072
-//   Eras: 38980
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 39220
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 1032
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93944
+//   TOTAL: 94184
 //
 // DO NOT EDIT
 
@@ -19600,6 +19600,18 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
+  // Rule Palestine    2072    max    -    Oct    Sat<=30    2:00    0    -
+  {
+    2072 /*from_year*/,
+    32766 /*to_year*/,
+    10 /*in_month*/,
+    6 /*on_day_of_week*/,
+    -30 /*on_day_of_month*/,
+    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
+    480 /*at_time_code (7200/15)*/,
+    0 /*delta_minutes*/,
+    0 /*letterIndex ("")*/,
+  },
   // Rule Palestine    2073    only    -    Sep     2    2:00    0    -
   {
     2073 /*from_year*/,
@@ -19671,18 +19683,6 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
-  },
-  // Rule Palestine    2075    max    -    Oct    Sat<=30    2:00    0    -
-  {
-    2075 /*from_year*/,
-    32766 /*to_year*/,
-    10 /*in_month*/,
-    6 /*on_day_of_week*/,
-    -30 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    0 /*delta_minutes*/,
-    0 /*letterIndex ("")*/,
   },
   // Rule Palestine    2076    only    -    Jul    25    2:00    0    -
   {

--- a/src/zonedball/zone_policies.c
+++ b/src/zonedball/zone_policies.c
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
+// Lower/Upper Truncated: [False, False]
+//
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8
 //

--- a/src/zonedball/zone_policies.c
+++ b/src/zonedball/zone_policies.c
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [1800,2200]
+// Accurate Years: [-32767,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
-// Lower/Upper Truncated: [False, False]
+// Lower/Upper Truncated: [False,False]
 //
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8

--- a/src/zonedball/zone_policies.c
+++ b/src/zonedball/zone_policies.c
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcAll
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 1800
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedball/zone_policies.c
+++ b/src/zonedball/zone_policies.c
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800

--- a/src/zonedball/zone_policies.c
+++ b/src/zonedball/zone_policies.c
@@ -41,6 +41,7 @@
 //   Rules: 2238
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 26856
 //   Policies: 402
 //   Eras: 29235
@@ -51,9 +52,10 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75701
+//   TOTAL: 75717
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 26856
 //   Policies: 1072
 //   Eras: 38980
@@ -64,7 +66,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93920
+//   TOTAL: 93944
 //
 // DO NOT EDIT
 

--- a/src/zonedball/zone_policies.h
+++ b/src/zonedball/zone_policies.h
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
+// Lower/Upper Truncated: [False, False]
+//
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8
 //

--- a/src/zonedball/zone_policies.h
+++ b/src/zonedball/zone_policies.h
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [1800,2200]
+// Accurate Years: [-32767,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
-// Lower/Upper Truncated: [False, False]
+// Lower/Upper Truncated: [False,False]
 //
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8

--- a/src/zonedball/zone_policies.h
+++ b/src/zonedball/zone_policies.h
@@ -41,6 +41,7 @@
 //   Rules: 2238
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 26856
 //   Policies: 402
 //   Eras: 29235
@@ -51,9 +52,10 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75701
+//   TOTAL: 75717
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 26856
 //   Policies: 1072
 //   Eras: 38980
@@ -64,7 +66,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93920
+//   TOTAL: 93944
 //
 // DO NOT EDIT
 
@@ -79,7 +81,6 @@ extern "C" {
 
 //---------------------------------------------------------------------------
 // Supported policies: 134
-// Supported rules: 2238
 //---------------------------------------------------------------------------
 
 extern const AtcZonePolicy kAtcAllZonePolicyAN;

--- a/src/zonedball/zone_policies.h
+++ b/src/zonedball/zone_policies.h
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcAll
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 1800
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedball/zone_policies.h
+++ b/src/zonedball/zone_policies.h
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800

--- a/src/zonedball/zone_policies.h
+++ b/src/zonedball/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1949
+//   Eras: 1961
 //   Policies: 134
 //   Rules: 2238
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 26856
 //   Policies: 402
-//   Eras: 29235
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 29415
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 1032
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75717
+//   TOTAL: 75897
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 26856
 //   Policies: 1072
-//   Eras: 38980
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 39220
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 1032
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93944
+//   TOTAL: 94184
 //
 // DO NOT EDIT
 

--- a/src/zonedball/zone_registry.c
+++ b/src/zonedball/zone_registry.c
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
+// Lower/Upper Truncated: [False, False]
+//
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8
 //

--- a/src/zonedball/zone_registry.c
+++ b/src/zonedball/zone_registry.c
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [1800,2200]
+// Accurate Years: [-32767,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
-// Lower/Upper Truncated: [False, False]
+// Lower/Upper Truncated: [False,False]
 //
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8

--- a/src/zonedball/zone_registry.c
+++ b/src/zonedball/zone_registry.c
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcAll
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 1800
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedball/zone_registry.c
+++ b/src/zonedball/zone_registry.c
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800

--- a/src/zonedball/zone_registry.c
+++ b/src/zonedball/zone_registry.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1949
+//   Eras: 1961
 //   Policies: 134
 //   Rules: 2238
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 26856
 //   Policies: 402
-//   Eras: 29235
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 29415
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 1032
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75717
+//   TOTAL: 75897
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 26856
 //   Policies: 1072
-//   Eras: 38980
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 39220
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 1032
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93944
+//   TOTAL: 94184
 //
 // DO NOT EDIT
 
@@ -81,7 +81,7 @@
 //---------------------------------------------------------------------------
 // Zone Info registry. Sorted by zoneId.
 //---------------------------------------------------------------------------
-const AtcZoneInfo * const kAtcAllZoneRegistry[350]  = {
+const AtcZoneInfo * const kAtcAllZoneRegistry[351]  = {
   &kAtcAllZoneAmerica_St_Johns, // 0x04b14e6e, America/St_Johns
   &kAtcAllZoneAmerica_North_Dakota_New_Salem, // 0x04f9958e, America/North_Dakota/New_Salem
   &kAtcAllZoneAsia_Jakarta, // 0x0506ab50, Asia/Jakarta
@@ -184,6 +184,7 @@ const AtcZoneInfo * const kAtcAllZoneRegistry[350]  = {
   &kAtcAllZoneAsia_Nicosia, // 0x4b0fcf78, Asia/Nicosia
   &kAtcAllZoneAmerica_Chicago, // 0x4b92b5d4, America/Chicago
   &kAtcAllZoneAustralia_Sydney, // 0x4d1e9776, Australia/Sydney
+  &kAtcAllZoneAntarctica_Vostok, // 0x4f966fd4, Antarctica/Vostok
   &kAtcAllZoneAustralia_Brisbane, // 0x4fedc9c0, Australia/Brisbane
   &kAtcAllZoneAmerica_Asuncion, // 0x50ec79a6, America/Asuncion
   &kAtcAllZoneAsia_Karachi, // 0x527f5245, Asia/Karachi
@@ -610,7 +611,7 @@ const AtcZoneInfo * const kAtcAllZoneAndLinkRegistry[596]  = {
   &kAtcAllZoneAustralia_Sydney, // 0x4d1e9776, Australia/Sydney
   &kAtcAllZoneNZ_CHAT, // 0x4d42afda, NZ-CHAT -> Pacific/Chatham
   &kAtcAllZoneUS_Arizona, // 0x4ec52670, US/Arizona -> America/Phoenix
-  &kAtcAllZoneAntarctica_Vostok, // 0x4f966fd4, Antarctica/Vostok -> Asia/Urumqi
+  &kAtcAllZoneAntarctica_Vostok, // 0x4f966fd4, Antarctica/Vostok
   &kAtcAllZoneUS_Aleutian, // 0x4fe013ef, US/Aleutian -> America/Adak
   &kAtcAllZoneAustralia_Brisbane, // 0x4fedc9c0, Australia/Brisbane
   &kAtcAllZoneAmerica_Catamarca, // 0x5036e963, America/Catamarca -> America/Argentina/Catamarca

--- a/src/zonedball/zone_registry.c
+++ b/src/zonedball/zone_registry.c
@@ -41,6 +41,7 @@
 //   Rules: 2238
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 26856
 //   Policies: 402
 //   Eras: 29235
@@ -51,9 +52,10 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75701
+//   TOTAL: 75717
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 26856
 //   Policies: 1072
 //   Eras: 38980
@@ -64,7 +66,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93920
+//   TOTAL: 93944
 //
 // DO NOT EDIT
 

--- a/src/zonedball/zone_registry.h
+++ b/src/zonedball/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
-// Supported Zones: 596 (350 zones, 246 links)
+// Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1949
+//   Eras: 1961
 //   Policies: 134
 //   Rules: 2238
 //
@@ -49,29 +49,29 @@
 //   Context: 16
 //   Rules: 26856
 //   Policies: 402
-//   Eras: 29235
-//   Zones: 4550
-//   Links: 3198
+//   Eras: 29415
+//   Zones: 4563
+//   Links: 3185
 //   Registry: 1192
 //   Formats: 1032
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75717
+//   TOTAL: 75897
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 26856
 //   Policies: 1072
-//   Eras: 38980
-//   Zones: 8400
-//   Links: 5904
+//   Eras: 39220
+//   Zones: 8424
+//   Links: 5880
 //   Registry: 2384
 //   Formats: 1032
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93944
+//   TOTAL: 94184
 //
 // DO NOT EDIT
 
@@ -85,8 +85,8 @@ extern "C" {
 #endif
 
 // Zones
-#define kAtcAllZoneRegistrySize 350
-extern const AtcZoneInfo * const kAtcAllZoneRegistry[350];
+#define kAtcAllZoneRegistrySize 351
+extern const AtcZoneInfo * const kAtcAllZoneRegistry[351];
 
 // Zones and Links
 #define kAtcAllZoneAndLinkRegistrySize 596

--- a/src/zonedball/zone_registry.h
+++ b/src/zonedball/zone_registry.h
@@ -31,6 +31,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
+// Lower/Upper Truncated: [False, False]
+//
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8
 //

--- a/src/zonedball/zone_registry.h
+++ b/src/zonedball/zone_registry.h
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //
 // using the TZ Database files
@@ -29,9 +29,12 @@
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
+// Requested Years: [1800,2200]
+// Accurate Years: [-32767,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1844,2087]
-// Lower/Upper Truncated: [False, False]
+// Lower/Upper Truncated: [False,False]
 //
 // Estimator Years: [1800,2090]
 // Max Buffer Size: 8

--- a/src/zonedball/zone_registry.h
+++ b/src/zonedball/zone_registry.h
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcAll
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 1800
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedball/zone_registry.h
+++ b/src/zonedball/zone_registry.h
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcAll
 //     --start_year 1800

--- a/src/zonedball/zone_registry.h
+++ b/src/zonedball/zone_registry.h
@@ -41,6 +41,7 @@
 //   Rules: 2238
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 26856
 //   Policies: 402
 //   Eras: 29235
@@ -51,9 +52,10 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75701
+//   TOTAL: 75717
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 26856
 //   Policies: 1072
 //   Eras: 38980
@@ -64,7 +66,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 93920
+//   TOTAL: 93944
 //
 // DO NOT EDIT
 

--- a/src/zonedbtesting/Makefile
+++ b/src/zonedbtesting/Makefile
@@ -18,13 +18,8 @@ all:
 		--tag $(TZ_VERSION) \
 		--action zonedb \
 		--language c \
-		--scope extended \
+		--scope complete \
 		--db_namespace AtcTesting \
-		--offset_granularity 1 \
-		--delta_granularity 60 \
-		--until_at_granularity 1 \
-		--generate_int16_years \
-		--generate_hires \
 		--start_year $(START_YEAR) \
 		--until_year $(UNTIL_YEAR) \
 		--nocompress \
@@ -36,10 +31,10 @@ zonedb.json:
 		--tag $(TZ_VERSION) \
 		--action zonedb \
 		--language json \
-		--scope extended \
-		--generate_int16_years \
+		--scope complete \
 		--start_year $(START_YEAR) \
 		--until_year $(UNTIL_YEAR)
+		--include_list include_list.txt
 
 clean:
 	rm -rf tzfiles zonedb.json

--- a/src/zonedbtesting/Makefile
+++ b/src/zonedbtesting/Makefile
@@ -16,8 +16,8 @@ all:
 	$(TOOLS)/tzcompiler.sh \
 		--tzrepo $(TZ_REPO) \
 		--tag $(TZ_VERSION) \
-		--action zonedb \
-		--language c \
+		--actions zonedb \
+		--languages c \
 		--scope complete \
 		--db_namespace AtcTesting \
 		--start_year $(START_YEAR) \
@@ -29,8 +29,8 @@ zonedb.json:
 	$(TOOLS)/tzcompiler.sh \
 		--tzrepo $(TZ_REPO) \
 		--tag $(TZ_VERSION) \
-		--action zonedb \
-		--language json \
+		--actions json \
+		--languages c \
 		--scope complete \
 		--start_year $(START_YEAR) \
 		--until_year $(UNTIL_YEAR)

--- a/src/zonedbtesting/Makefile
+++ b/src/zonedbtesting/Makefile
@@ -8,7 +8,7 @@ zone_registry.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2023c
+TZ_VERSION := 2023d
 START_YEAR := 2000 # unit tests assume start year 2000
 UNTIL_YEAR := 2200
 

--- a/src/zonedbtesting/Makefile
+++ b/src/zonedbtesting/Makefile
@@ -10,7 +10,7 @@ TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
 TZ_VERSION := 2023c
 START_YEAR := 2000 # unit tests assume start year 2000
-UNTIL_YEAR := 10000
+UNTIL_YEAR := 2200
 
 all:
 	$(TOOLS)/tzcompiler.sh \

--- a/src/zonedbtesting/zone_infos.c
+++ b/src/zonedbtesting/zone_infos.c
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcTesting
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedbtesting/zone_infos.c
+++ b/src/zonedbtesting/zone_infos.c
@@ -32,6 +32,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedbtesting/zone_infos.c
+++ b/src/zonedbtesting/zone_infos.c
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000

--- a/src/zonedbtesting/zone_infos.c
+++ b/src/zonedbtesting/zone_infos.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (334 zones, 245 links)
+// Unsupported Zones: 579 (335 zones, 244 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]
@@ -83,7 +83,7 @@
 // ZoneContext
 //---------------------------------------------------------------------------
 
-static const char kAtcTzDatabaseVersion[] = "2023c";
+static const char kAtcTzDatabaseVersion[] = "2023d";
 
 static const char * const kAtcFragments[] = {
 /*\x00*/ NULL,

--- a/src/zonedbtesting/zone_infos.c
+++ b/src/zonedbtesting/zone_infos.c
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //     --include_list include_list.txt
 //
@@ -30,9 +30,12 @@
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (334 zones, 245 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7
@@ -98,7 +101,9 @@ static const char* const kAtcLetters[] = {
 
 const AtcZoneContext kAtcTestingZoneContext = {
   2000 /*start_year*/,
-  10000 /*until_year*/,
+  2200 /*until_year*/,
+  2000 /*start_year_accurate*/,
+  32767 /*until_year_accurate*/,
   7 /*max_transitions*/,
   kAtcTzDatabaseVersion /*tz_version*/,
   1 /*num_fragments*/,

--- a/src/zonedbtesting/zone_infos.c
+++ b/src/zonedbtesting/zone_infos.c
@@ -42,6 +42,7 @@
 //   Rules: 201
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 2412
 //   Policies: 24
 //   Eras: 330
@@ -52,9 +53,10 @@
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3390
+//   TOTAL: 3406
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 2412
 //   Policies: 64
 //   Eras: 440
@@ -65,7 +67,7 @@
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3771
+//   TOTAL: 3795
 //
 // DO NOT EDIT
 
@@ -73,7 +75,7 @@
 #include "zone_infos.h"
 
 //---------------------------------------------------------------------------
-// ZoneContext (should not be in PROGMEM)
+// ZoneContext
 //---------------------------------------------------------------------------
 
 static const char kAtcTzDatabaseVersion[] = "2023c";

--- a/src/zonedbtesting/zone_infos.h
+++ b/src/zonedbtesting/zone_infos.h
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //     --include_list include_list.txt
 //
@@ -30,9 +30,12 @@
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (334 zones, 245 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7

--- a/src/zonedbtesting/zone_infos.h
+++ b/src/zonedbtesting/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (334 zones, 245 links)
+// Unsupported Zones: 579 (335 zones, 244 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]
@@ -174,7 +174,7 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 
 
 //---------------------------------------------------------------------------
-// Unsupported zones: 334
+// Unsupported zones: 335
 //---------------------------------------------------------------------------
 
 // Africa/Abidjan {Zone missing from include list}
@@ -311,6 +311,7 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // Antarctica/Palmer {Zone missing from include list}
 // Antarctica/Rothera {Zone missing from include list}
 // Antarctica/Troll {Zone missing from include list}
+// Antarctica/Vostok {Zone missing from include list}
 // Asia/Almaty {Zone missing from include list}
 // Asia/Amman {Zone missing from include list}
 // Asia/Anadyr {Zone missing from include list}
@@ -530,7 +531,7 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 
 
 //---------------------------------------------------------------------------
-// Unsupported links: 245
+// Unsupported links: 244
 //---------------------------------------------------------------------------
 
 // Africa/Accra {Link missing from include list}
@@ -620,7 +621,6 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // Antarctica/McMurdo {Link missing from include list}
 // Antarctica/South_Pole {Link missing from include list}
 // Antarctica/Syowa {Link missing from include list}
-// Antarctica/Vostok {Link missing from include list}
 // Arctic/Longyearbyen {Link missing from include list}
 // Asia/Aden {Link missing from include list}
 // Asia/Ashkhabad {Link missing from include list}

--- a/src/zonedbtesting/zone_infos.h
+++ b/src/zonedbtesting/zone_infos.h
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcTesting
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedbtesting/zone_infos.h
+++ b/src/zonedbtesting/zone_infos.h
@@ -32,6 +32,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedbtesting/zone_infos.h
+++ b/src/zonedbtesting/zone_infos.h
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000

--- a/src/zonedbtesting/zone_infos.h
+++ b/src/zonedbtesting/zone_infos.h
@@ -42,6 +42,7 @@
 //   Rules: 201
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 2412
 //   Policies: 24
 //   Eras: 330
@@ -52,9 +53,10 @@
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3390
+//   TOTAL: 3406
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 2412
 //   Policies: 64
 //   Eras: 440
@@ -65,7 +67,7 @@
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3771
+//   TOTAL: 3795
 //
 // DO NOT EDIT
 

--- a/src/zonedbtesting/zone_policies.c
+++ b/src/zonedbtesting/zone_policies.c
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //     --include_list include_list.txt
 //
@@ -30,9 +30,12 @@
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (334 zones, 245 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7

--- a/src/zonedbtesting/zone_policies.c
+++ b/src/zonedbtesting/zone_policies.c
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcTesting
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedbtesting/zone_policies.c
+++ b/src/zonedbtesting/zone_policies.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (334 zones, 245 links)
+// Unsupported Zones: 579 (335 zones, 244 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]

--- a/src/zonedbtesting/zone_policies.c
+++ b/src/zonedbtesting/zone_policies.c
@@ -32,6 +32,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedbtesting/zone_policies.c
+++ b/src/zonedbtesting/zone_policies.c
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000

--- a/src/zonedbtesting/zone_policies.c
+++ b/src/zonedbtesting/zone_policies.c
@@ -42,6 +42,7 @@
 //   Rules: 201
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 2412
 //   Policies: 24
 //   Eras: 330
@@ -52,9 +53,10 @@
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3390
+//   TOTAL: 3406
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 2412
 //   Policies: 64
 //   Eras: 440
@@ -65,7 +67,7 @@
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3771
+//   TOTAL: 3795
 //
 // DO NOT EDIT
 

--- a/src/zonedbtesting/zone_policies.h
+++ b/src/zonedbtesting/zone_policies.h
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //     --include_list include_list.txt
 //
@@ -30,9 +30,12 @@
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (334 zones, 245 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7

--- a/src/zonedbtesting/zone_policies.h
+++ b/src/zonedbtesting/zone_policies.h
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcTesting
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedbtesting/zone_policies.h
+++ b/src/zonedbtesting/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (334 zones, 245 links)
+// Unsupported Zones: 579 (335 zones, 244 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]

--- a/src/zonedbtesting/zone_policies.h
+++ b/src/zonedbtesting/zone_policies.h
@@ -32,6 +32,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedbtesting/zone_policies.h
+++ b/src/zonedbtesting/zone_policies.h
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000

--- a/src/zonedbtesting/zone_policies.h
+++ b/src/zonedbtesting/zone_policies.h
@@ -42,6 +42,7 @@
 //   Rules: 201
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 2412
 //   Policies: 24
 //   Eras: 330
@@ -52,9 +53,10 @@
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3390
+//   TOTAL: 3406
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 2412
 //   Policies: 64
 //   Eras: 440
@@ -65,7 +67,7 @@
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3771
+//   TOTAL: 3795
 //
 // DO NOT EDIT
 
@@ -80,7 +82,6 @@ extern "C" {
 
 //---------------------------------------------------------------------------
 // Supported policies: 8
-// Supported rules: 201
 //---------------------------------------------------------------------------
 
 extern const AtcZonePolicy kAtcTestingZonePolicyAus;

--- a/src/zonedbtesting/zone_registry.c
+++ b/src/zonedbtesting/zone_registry.c
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //     --include_list include_list.txt
 //
@@ -30,9 +30,12 @@
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (334 zones, 245 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7

--- a/src/zonedbtesting/zone_registry.c
+++ b/src/zonedbtesting/zone_registry.c
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcTesting
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedbtesting/zone_registry.c
+++ b/src/zonedbtesting/zone_registry.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (334 zones, 245 links)
+// Unsupported Zones: 579 (335 zones, 244 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]

--- a/src/zonedbtesting/zone_registry.c
+++ b/src/zonedbtesting/zone_registry.c
@@ -32,6 +32,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedbtesting/zone_registry.c
+++ b/src/zonedbtesting/zone_registry.c
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000

--- a/src/zonedbtesting/zone_registry.c
+++ b/src/zonedbtesting/zone_registry.c
@@ -42,6 +42,7 @@
 //   Rules: 201
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 2412
 //   Policies: 24
 //   Eras: 330
@@ -52,9 +53,10 @@
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3390
+//   TOTAL: 3406
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 2412
 //   Policies: 64
 //   Eras: 440
@@ -65,7 +67,7 @@
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3771
+//   TOTAL: 3795
 //
 // DO NOT EDIT
 

--- a/src/zonedbtesting/zone_registry.h
+++ b/src/zonedbtesting/zone_registry.h
@@ -9,7 +9,7 @@
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000
-//     --until_year 10000
+//     --until_year 2200
 //     --nocompress
 //     --include_list include_list.txt
 //
@@ -30,9 +30,12 @@
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (334 zones, 245 links)
 //
+// Requested Years: [2000,2200]
+// Accurate Years: [2000,32767]
+//
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
-// Lower/Upper Truncated: [True, False]
+// Lower/Upper Truncated: [True,False]
 //
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7

--- a/src/zonedbtesting/zone_registry.h
+++ b/src/zonedbtesting/zone_registry.h
@@ -6,13 +6,8 @@
 //     --tz_version 2023c
 //     --action zonedb
 //     --language c
-//     --scope extended
+//     --scope complete
 //     --db_namespace AtcTesting
-//     --offset_granularity 1
-//     --delta_granularity 60
-//     --until_at_granularity 1
-//     --generate_int16_years
-//     --generate_hires
 //     --start_year 2000
 //     --until_year 10000
 //     --nocompress

--- a/src/zonedbtesting/zone_registry.h
+++ b/src/zonedbtesting/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023c
+//     --tz_version 2023d
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023c
+// from https://github.com/eggert/tz/releases/tag/2023d
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (334 zones, 245 links)
+// Unsupported Zones: 579 (335 zones, 244 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]

--- a/src/zonedbtesting/zone_registry.h
+++ b/src/zonedbtesting/zone_registry.h
@@ -32,6 +32,8 @@
 //
 // Original Years:  [1844,2087]
 // Generated Years: [1966,2087]
+// Lower/Upper Truncated: [True, False]
+//
 // Estimator Years: [1966,2090]
 // Max Buffer Size: 7
 //

--- a/src/zonedbtesting/zone_registry.h
+++ b/src/zonedbtesting/zone_registry.h
@@ -4,8 +4,8 @@
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
 //     --tz_version 2023c
-//     --action zonedb
-//     --language c
+//     --actions zonedb
+//     --languages c
 //     --scope complete
 //     --db_namespace AtcTesting
 //     --start_year 2000

--- a/src/zonedbtesting/zone_registry.h
+++ b/src/zonedbtesting/zone_registry.h
@@ -42,6 +42,7 @@
 //   Rules: 201
 //
 // Memory (8-bits):
+//   Context: 16
 //   Rules: 2412
 //   Policies: 24
 //   Eras: 330
@@ -52,9 +53,10 @@
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3390
+//   TOTAL: 3406
 //
 // Memory (32-bits):
+//   Context: 24
 //   Rules: 2412
 //   Policies: 64
 //   Eras: 440
@@ -65,7 +67,7 @@
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3771
+//   TOTAL: 3795
 //
 // DO NOT EDIT
 

--- a/src/zoneinfo/zone_info.h
+++ b/src/zoneinfo/zone_info.h
@@ -34,21 +34,21 @@ enum {
    * by synthetic entries for certain zones, to guarantee that all zones have at
    * least one transition.
    */
-  kAtcMinZoneRuleYear = -32767,
+  kAtcMinYear = -32767,
 
   /**
    * The maximum value of AtcZoneRule::from_year and AtcZoneRule::to_year,
    * representing the sentinel value "max" in the TO and FROM columns of the
-   * TZDB files. Must be less than kAtcMaxZoneEraUntilYear.
+   * TZDB files. Must be less than kAtcMaxUntilYear.
    */
-  kAtcMaxZoneRuleYear = 32766,
+  kAtcMaxYear = 32766,
 
   /**
    * The maximum value of ZoneEra::until_year, representing the sentinel value
    * "-" in the UNTIL column of the TZDB files. Must be greater than
-   * kAtcMaxZoneRuleYear.
+   * kAtcMaxYear.
    */
-  kAtcMaxZoneEraUntilYear = kAtcMaxZoneRuleYear + 1,
+  kAtcMaxUntilYear = kAtcMaxYear + 1,
 };
 
 //---------------------------------------------------------------------------
@@ -204,15 +204,11 @@ typedef struct AtcZoneContext {
   /** Until year of the zone files as requested. */
   int16_t until_year;
 
-  /**
-   * Start year of accurate transitions. kAtcMinZoneRuleYear indicates
-   * -Infinity
-   */
+  /** Start year of accurate transitions. kAtcMinYear indicates -Infinity */
   int16_t start_year_accurate;
 
   /**
-   * Until year of accurate transitions. kAtcMaxZoneEraUntilYear indicates
-   * +Infinity
+   * Until year of accurate transitions. kAtcMaxUntilYear indicates +Infinity
    */
   int16_t until_year_accurate;
 

--- a/src/zoneinfo/zone_info.h
+++ b/src/zoneinfo/zone_info.h
@@ -34,21 +34,21 @@ enum {
    * by synthetic entries for certain zones, to guarantee that all zones have at
    * least one transition.
    */
-  kAtcMinYear = -32767,
+  kAtcZoneInfoMinYear = -32767,
 
   /**
    * The maximum value of AtcZoneRule::from_year and AtcZoneRule::to_year,
    * representing the sentinel value "max" in the TO and FROM columns of the
    * TZDB files. Must be less than kAtcMaxUntilYear.
    */
-  kAtcMaxYear = 32766,
+  kAtcZoneInfoMaxYear = 32766,
 
   /**
    * The maximum value of ZoneEra::until_year, representing the sentinel value
    * "-" in the UNTIL column of the TZDB files. Must be greater than
-   * kAtcMaxYear.
+   * kAtcZoneInfoMaxYear.
    */
-  kAtcMaxUntilYear = kAtcMaxYear + 1,
+  kAtcZoneInfoMaxUntilYear = kAtcZoneInfoMaxYear + 1,
 };
 
 //---------------------------------------------------------------------------
@@ -204,11 +204,15 @@ typedef struct AtcZoneContext {
   /** Until year of the zone files as requested. */
   int16_t until_year;
 
-  /** Start year of accurate transitions. kAtcMinYear indicates -Infinity */
+  /**
+   * Start year of accurate transitions. kAtcZoneInfoMinYear indicates
+   * -Infinity
+   */
   int16_t start_year_accurate;
 
   /**
-   * Until year of accurate transitions. kAtcMaxUntilYear indicates +Infinity
+   * Until year of accurate transitions. kAtcZoneInfoMaxUntilYear indicates
+   * +Infinity
    */
   int16_t until_year_accurate;
 

--- a/src/zoneinfo/zone_info.h
+++ b/src/zoneinfo/zone_info.h
@@ -198,11 +198,23 @@ enum {
 
 /** Information about the zone database. */
 typedef struct AtcZoneContext {
-  /** Start year of the zone files. */
+  /** Start year of the zone files as requested. */
   int16_t start_year;
 
-  /** Until year of the zone files. */
+  /** Until year of the zone files as requested. */
   int16_t until_year;
+
+  /**
+   * Start year of accurate transitions. kAtcMinZoneRuleYear indicates
+   * -Infinity
+   */
+  int16_t start_year_accurate;
+
+  /**
+   * Until year of accurate transitions. kAtcMaxZoneEraUntilYear indicates
+   * +Infinity
+   */
+  int16_t until_year_accurate;
 
   /** The maximum transitions required in TransitionStorage. */
   int16_t max_transitions;

--- a/tests/zonedb_test.c
+++ b/tests/zonedb_test.c
@@ -1,6 +1,14 @@
 #include <acunit.h>
 #include <acetimec.h>
 
+// These tests often break and need to be updated when the TZDB is upgraded to a
+// new version. In that sense, they are somewhat annoying. On the other hand,
+// they run the simplest sanity check, reading the total number of zones. They
+// are useful when we do a major refactoring and the unit tests fall apart. It's
+// useful to have this as a baseline so that we can rebuild the rest of the
+// testing infrastructure.
+// 
+
 ACU_TEST(test_zonedb_sizes)
 {
   // These numbers are correct for TZDB 2023d
@@ -10,7 +18,7 @@ ACU_TEST(test_zonedb_sizes)
 
 ACU_TEST(test_zonedball_sizes)
 {
-  // These numbers are correct for TZDB 2023c
+  // These numbers are correct for TZDB 2023d
   ACU_ASSERT(sizeof(kAtcAllZoneRegistry) / sizeof(AtcZoneInfo*) == 351);
   ACU_ASSERT(sizeof(kAtcAllZoneAndLinkRegistry) / sizeof(AtcZoneInfo*) == 596);
 }

--- a/tests/zonedb_test.c
+++ b/tests/zonedb_test.c
@@ -3,15 +3,15 @@
 
 ACU_TEST(test_zonedb_sizes)
 {
-  // These numbers are correct for TZDB 2023c
-  ACU_ASSERT(sizeof(kAtcZoneRegistry) / sizeof(AtcZoneInfo*) == 350);
+  // These numbers are correct for TZDB 2023d
+  ACU_ASSERT(sizeof(kAtcZoneRegistry) / sizeof(AtcZoneInfo*) == 351);
   ACU_ASSERT(sizeof(kAtcZoneAndLinkRegistry) / sizeof(AtcZoneInfo*) == 596);
 }
 
 ACU_TEST(test_zonedball_sizes)
 {
   // These numbers are correct for TZDB 2023c
-  ACU_ASSERT(sizeof(kAtcAllZoneRegistry) / sizeof(AtcZoneInfo*) == 350);
+  ACU_ASSERT(sizeof(kAtcAllZoneRegistry) / sizeof(AtcZoneInfo*) == 351);
   ACU_ASSERT(sizeof(kAtcAllZoneAndLinkRegistry) / sizeof(AtcZoneInfo*) == 596);
 }
 


### PR DESCRIPTION
* 0.11.1 (2024-01-12, TZDB 2023d)
    * Upgrade TZDB to 2023d
        * https://mm.icann.org/pipermail/tz-announce/2023-December/000080.html
        * "Ittoqqortoormiit, Greenland changes time zones on 2024-03-31. Vostok,
          Antarctica changed time zones on 2023-12-18. Casey, Antarctica changed
          time zones five times since 2020. Code and data fixes for Palestine
          timestamps starting in 2072. A new data file zonenow.tab for
          timestamps starting now."
