### PR TITLE
merge 0.11.2 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,242 +1,248 @@
 # Changelog
 
-* Unreleased
-* 0.11.1 (2024-01-12, TZDB 2023d)
-    * Upgrade TZDB to 2023d
-        * https://mm.icann.org/pipermail/tz-announce/2023-December/000080.html
-        * "Ittoqqortoormiit, Greenland changes time zones on 2024-03-31. Vostok,
+- Unreleased
+    - Upgrade TZDB to 2024a
+        - https://mm.icann.org/pipermail/tz-announce/2024-February/000081.html
+        - "Kazakhstan unifies on UTC+5 beginning 2024-03-01. Palestine springs
+          forward a week later after Ramadan. zic no longer pretends to support
+          indefinite-past DST. localtime no longer mishandles Ciudad Juárez in
+          2422."
+- 0.11.1 (2024-01-12, TZDB 2023d)
+    - Upgrade TZDB to 2023d
+        - https://mm.icann.org/pipermail/tz-announce/2023-December/000080.html
+        - "Ittoqqortoormiit, Greenland changes time zones on 2024-03-31. Vostok,
           Antarctica changed time zones on 2023-12-18. Casey, Antarctica changed
           time zones five times since 2020. Code and data fixes for Palestine
           timestamps starting in 2072. A new data file zonenow.tab for
           timestamps starting now."
-* 0.11.0 (2023-05-31, TZDB 2023c)
-    * Update path to ACUnit from https://github.com/bxparks/ACUnit (v0.1) to
+- 0.11.0 (2023-05-31, TZDB 2023c)
+    - Update path to ACUnit from https://github.com/bxparks/ACUnit (v0.1) to
       https://github.com/bxparks/acunit (v0.2).
-    * Support LocalDateTime, OffsetDateTime, and ZonedDateTime to and from
+    - Support LocalDateTime, OffsetDateTime, and ZonedDateTime to and from
       64-bit unix seconds.
-    * `zone_processor.c`
-        * Automatically invalidate the transitions cache when the
+    - `zone_processor.c`
+        - Automatically invalidate the transitions cache when the
           current epoch year is changed through `atc_set_current_epoch_year()`.
-    * `zone_extra.h`
-        * Rename `AtcZonedExtra.type` to `fold_type`.
-        * Rename `kAtcZonedExtraXxx` constants to `kAtcFoldTypeXxx`.
-* 0.10.0 (2023-05-19, TZDB 2023c)
-    * Rename `AceTimeC` to `acetimec`
-        * Better consistency with most other C libraries
-        * More consistent with the `acetimepy` library in Python.
-        * Allows better distinction my various various Arduino libraries with
+    - `zone_extra.h`
+        - Rename `AtcZonedExtra.type` to `fold_type`.
+        - Rename `kAtcZonedExtraXxx` constants to `kAtcFoldTypeXxx`.
+- 0.10.0 (2023-05-19, TZDB 2023c)
+    - Rename `AceTimeC` to `acetimec`
+        - Better consistency with most other C libraries
+        - More consistent with the `acetimepy` library in Python.
+        - Allows better distinction my various various Arduino libraries with
           the naming pattern `AceXxx`.
-        * More consistent with the `acetimec.h` header file, and `acetimec.a`
+        - More consistent with the `acetimec.h` header file, and `acetimec.a`
           archive file.
-* 0.9.1 (2023-05-19, TZDB 2023c)
-    * `zone_processor.c`
-        * Fix bug which prevented the transition cache from working after
+- 0.9.1 (2023-05-19, TZDB 2023c)
+    - `zone_processor.c`
+        - Fix bug which prevented the transition cache from working after
           `atc_processor_init_for_year().
-        * Increases performance by ~7X.
-* 0.9.0 (2023-05-11, TZDB 2023c)
-    * Replace `err` return value from most external functions if there is an
+        - Increases performance by ~7X.
+- 0.9.0 (2023-05-11, TZDB 2023c)
+    - Replace `err` return value from most external functions if there is an
       out-parameter on the function signature (e.g. `AtcZonedDateTime`) that can
       be sets to an error state.
-        * Simplifies the API with only a single place to check for errors.
-        * Error conditions are now be detected using:
-            * `atc_local_date_time_is_error()`
-            * `atc_offset_date_time_is_error()`
-            * `atc_zoned_date_time_is_error()`
-            * `atc_zoned_extra_is_error()`
-    * Change `atc_XXX_print()` functions to place `AtcStringBuffer` as first
+        - Simplifies the API with only a single place to check for errors.
+        - Error conditions are now be detected using:
+            - `atc_local_date_time_is_error()`
+            - `atc_offset_date_time_is_error()`
+            - `atc_zoned_date_time_is_error()`
+            - `atc_zoned_extra_is_error()`
+    - Change `atc_XXX_print()` functions to place `AtcStringBuffer` as first
       argument.
-        * This is more consistent with the `fprintf()` function.
-    * MemoryBenchmark
-        * Remove Teensy 3.2
-            * No longer recommended for new projects as of 2023-02-14
-            * "PJRC recommends use of Teensy 4.0 / 4.1 for new projects. We do
+        - This is more consistent with the `fprintf()` function.
+    - MemoryBenchmark
+        - Remove Teensy 3.2
+            - No longer recommended for new projects as of 2023-02-14
+            - "PJRC recommends use of Teensy 4.0 / 4.1 for new projects. We do
               not believe supply of chips for Teensy 3.x is likely to ever fully
               recover. These chips are made with 90 nm silicon process. Most of
               the world's semiconductor fabs are focusing on 45 nm or smaller,
               leaving limited supply for older chips. We anticipate the cost of
               these chips is likely to increase as the supply continues to
               dwindle"
-        * Add SAMD21 (Seeeduino XIAO) and SAMD51 (Adafruit ItsyBitsy M4).
-* 0.8.0 (2023-04-13, TZDB 2023c)
-    * Upgrade TZDB from 2023b to 2023c.
-        * https://mm.icann.org/pipermail/tz-announce/2023-March/000079.html
-            * "This release's code and data are identical to 2023a.  In other
+        - Add SAMD21 (Seeeduino XIAO) and SAMD51 (Adafruit ItsyBitsy M4).
+- 0.8.0 (2023-04-13, TZDB 2023c)
+    - Upgrade TZDB from 2023b to 2023c.
+        - https://mm.icann.org/pipermail/tz-announce/2023-March/000079.html
+            - "This release's code and data are identical to 2023a.  In other
               words, this release reverts all changes made in 2023b other than
               commentary, as that appears to be the best of a bad set of
               short-notice choices for modeling this week's daylight saving
               chaos in Lebanon."
-    * Add support for plain UTC timezone in `AtcTimeZone`.
-        * Create pre-defined `atc_time_zone_utc` instance.
-    * Move `AtcZonedExtra` factory functions to `AtcTimeZone`.
-        * Simplify initialization sequence of `AtcZoneProcessor` by channeling
+    - Add support for plain UTC timezone in `AtcTimeZone`.
+        - Create pre-defined `atc_time_zone_utc` instance.
+    - Move `AtcZonedExtra` factory functions to `AtcTimeZone`.
+        - Simplify initialization sequence of `AtcZoneProcessor` by channeling
           all factory operations through `AtcTimeZone`.
-    * zonedbs
-        * Create `zonedbtesting` for unit tests, using a limited number of
+    - zonedbs
+        - Create `zonedbtesting` for unit tests, using a limited number of
           zones, over only a limited [2000,10000] year range.
-        * Create `zonedball` using [1800,10000] which covers the entire range of
+        - Create `zonedball` using [1800,10000] which covers the entire range of
           the TZDB database, for all zones.
-        * Restrict range of `zonedb` to [2000,10000] again, to reduce size of
+        - Restrict range of `zonedb` to [2000,10000] again, to reduce size of
           database.
-    * High resolution zonedb
-        * Support one-second resolution for Zone.UNTIL and Rule.AT fields.
-            * Enables support all zones before ~1972.
-        * Support one-minute resolution for Zone.DSTOFF (i.e. Zone.RULES) and
+    - High resolution zonedb
+        - Support one-second resolution for Zone.UNTIL and Rule.AT fields.
+            - Enables support all zones before ~1972.
+        - Support one-minute resolution for Zone.DSTOFF (i.e. Zone.RULES) and
           Rule.SAVE fields.
-            * Handles a few zones around ~1930 whose DSTOFF is a 00:20 minutes,
+            - Handles a few zones around ~1930 whose DSTOFF is a 00:20 minutes,
             instead of a multiple of 00:15 minutes.
-        * Extend year interval of `zonedb/` to `[1800,10000)`, which is
+        - Extend year interval of `zonedb/` to `[1800,10000)`, which is
           slightly larger than the raw TZDB year range of `[1844,2087]` (as of
           TZDB 2022g).
-        * Increases flash consumption by roughly 100%, 40kB to 80kB on 32-bit
+        - Increases flash consumption by roughly 100%, 40kB to 80kB on 32-bit
           processors.
-        * The old format still available through `-D ATC_HIRES_ZONEDB=0`.
-        * Validation program `validate_against_libc/` shows that transitions
+        - The old format still available through `-D ATC_HIRES_ZONEDB=0`.
+        - Validation program `validate_against_libc/` shows that transitions
           are identical to the C libc library for all zones, for all years
           `[1800,2100)`.
-    * MemoryBenchmark
-        * Use my Arduino MemoryBenchmark infrastructure to extract flash and
+    - MemoryBenchmark
+        - Use my Arduino MemoryBenchmark infrastructure to extract flash and
           static memory consumption of the AceTimeC library across various
           microcontrollers.
-        * The library does not support `PROGMEM` so AVR and ESP8266 processors
+        - The library does not support `PROGMEM` so AVR and ESP8266 processors
           consume excessive RAM.
-    * Always generate anchor rules in zonedb.
-        * Allows `zone_processor.c` to work over all years `[0,10000)`
+    - Always generate anchor rules in zonedb.
+        - Allows `zone_processor.c` to work over all years `[0,10000)`
           even with truncated zonedb (e.g. `[2000,2100)`).
-        * Accuracy is guaranteed only for the requested interval (e.g.
+        - Accuracy is guaranteed only for the requested interval (e.g.
           `[2000,2100)`.
-        * But the code won't crash outside of that interval.
-        * Extend range of `from_year`, `to_year`, `until_year` to +/-32767.
-    * Zonedb Rule filtering
-        * Use simplified ZoneRule filtering from AceTimeTools.
-* 0.7.0 (2023-02-12, TZDB 2022g)
-    * Links
-        * Remove `kAtcLinkRegistry` and support for thin links.
-        * Add `target_info` field to `AtcZoneInfo` to unify fat and symbolic
+        - But the code won't crash outside of that interval.
+        - Extend range of `from_year`, `to_year`, `until_year` to +/-32767.
+    - Zonedb Rule filtering
+        - Use simplified ZoneRule filtering from AceTimeTools.
+- 0.7.0 (2023-02-12, TZDB 2022g)
+    - Links
+        - Remove `kAtcLinkRegistry` and support for thin links.
+        - Add `target_info` field to `AtcZoneInfo` to unify fat and symbolic
           links.
-    * Replace `AtcZoneInfo.letter` with `letter_index`.
-        * All letter fields are now indexes into `AtcZoneContext.letters` array,
+    - Replace `AtcZoneInfo.letter` with `letter_index`.
+        - All letter fields are now indexes into `AtcZoneContext.letters` array,
           even the one-character letters.
-    * New directory structure, similar to AceTimeGo library
-        * `src/ace_time_c/` -> `src/acetimec/`
-        * `src/ace_time_c/zone_info.h` -> `src/zoneinfo/*`
-        * `src/ace_time_c/zone_info_utils.h` -> `src/zoneinfo/*`
-        * `src/ace_time_c/zonedb/` -> `src/zonedb/`
-    * Validation
-        * Create `examples/validate_against_libc` to validate against the libc
+    - New directory structure, similar to AceTimeGo library
+        - `src/ace_time_c/` -> `src/acetimec/`
+        - `src/ace_time_c/zone_info.h` -> `src/zoneinfo/*`
+        - `src/ace_time_c/zone_info_utils.h` -> `src/zoneinfo/*`
+        - `src/ace_time_c/zonedb/` -> `src/zonedb/`
+    - Validation
+        - Create `examples/validate_against_libc` to validate against the libc
           time functions.
-    * examples/
-        * Add `-D _GNU_SOURCE` flag to gain access to `gm_gmtoff` field
+    - examples/
+        - Add `-D _GNU_SOURCE` flag to gain access to `gm_gmtoff` field
           in `struct tm`.
-        * Allows validation of total UTC offset against the GNU libc library.
-* 0.6.0 (2023-01-17, TZDB 2022g)
-    * Migrate to ACUnit v0.1.0.
-    * `atc_days_to_current_epoch_from_converter_epoch`
-        * Fix incorrect initial value.
-    * `atc_date_tuple_subtract()`
-        * Fix overflow bug.
-    * `zonedb`
-        * Rename `kAtcPolicyXxx` to `kAtcZonePolicyXxx` for consistency.
-    * `zone_processor.h`
-        * Renamed from `zone_processing.h`.
-        * Rename `AtcZoneProcessing` to `AtcZoneProcessor`.
-        * Incorporate same algorithm as AceTime
-        * Unify `find_by_epochseconds()` and `find_by_local_date_time()` using a
+        - Allows validation of total UTC offset against the GNU libc library.
+- 0.6.0 (2023-01-17, TZDB 2022g)
+    - Migrate to ACUnit v0.1.0.
+    - `atc_days_to_current_epoch_from_converter_epoch`
+        - Fix incorrect initial value.
+    - `atc_date_tuple_subtract()`
+        - Fix overflow bug.
+    - `zonedb`
+        - Rename `kAtcPolicyXxx` to `kAtcZonePolicyXxx` for consistency.
+    - `zone_processor.h`
+        - Renamed from `zone_processing.h`.
+        - Rename `AtcZoneProcessing` to `AtcZoneProcessor`.
+        - Incorporate same algorithm as AceTime
+        - Unify `find_by_epochseconds()` and `find_by_local_date_time()` using a
           common `FindResult`.
-        * Fix handling of input and output `fold` parameters during overlap in
+        - Fix handling of input and output `fold` parameters during overlap in
           `find_by_local_date_time()`.
-    * `AtcLocalDateTime`
-        * Incorporate `fold` parameter, for consistency with `AtcOffsetDateTime`
+    - `AtcLocalDateTime`
+        - Incorporate `fold` parameter, for consistency with `AtcOffsetDateTime`
           and `AtcZonedDateTime`.
-        * Removes the explicit `uint8_t fold` argument from a number of
+        - Removes the explicit `uint8_t fold` argument from a number of
           functions, simplifying their usage.
-        * More consistent with the AceTime library.
-    * `AtcZonedExtra`
-        * Add requested STD offset and DST offset, information which was
+        - More consistent with the AceTime library.
+    - `AtcZonedExtra`
+        - Add requested STD offset and DST offset, information which was
           otherwise lost during a DST gap.
-        * Add `type` parameter to indicate exact match, gap, or overlap.
-    * `AtcTimeZone`
-        * Add `AtcTimeZone` struct to simplify arguments to various
+        - Add `type` parameter to indicate exact match, gap, or overlap.
+    - `AtcTimeZone`
+        - Add `AtcTimeZone` struct to simplify arguments to various
           `atc_zoned_date_time*()` and `atc_zoned_extra*()` functions
-    * printing to `AtcStringBuffer`
-        * Change order of various `atc_xxx_print()` functions to place the
+    - printing to `AtcStringBuffer`
+        - Change order of various `atc_xxx_print()` functions to place the
           date-time objects first, like the `this` pointer of an object.
-* 0.5.0 (2022-12-04, TZDB 2022g)
-    * Upgrade to TZDB 2022g
-    * Add `extern "C"` to all header files.
-    * Rename `string_buffer.h` functions to `atc_buf_init()` and
+- 0.5.0 (2022-12-04, TZDB 2022g)
+    - Upgrade to TZDB 2022g
+    - Add `extern "C"` to all header files.
+    - Rename `string_buffer.h` functions to `atc_buf_init()` and
       `atc_buf_close()`. Add `atc_buf_reset()`.
-    * Create `AtcZoneRegistrar` data structure for the various
+    - Create `AtcZoneRegistrar` data structure for the various
       `atc_registrar_xxx()` functions.
-    * Add `examples/arduino/HelloTextClock` to test compilation under Arduino
+    - Add `examples/arduino/HelloTextClock` to test compilation under Arduino
       environment.
-* 0.4.0 (2022-11-04, TZDB 2022f)
-    * Configurable current epoch year
-        * Rename `atc_set_local_epoch_year()` and `atc_get_local_epoch_year()`
+- 0.4.0 (2022-11-04, TZDB 2022f)
+    - Configurable current epoch year
+        - Rename `atc_set_local_epoch_year()` and `atc_get_local_epoch_year()`
           to `atc_set_current_epoch_year()` and `atc_get_current_epoch_year()`,
           consistent with AceTime library.
-        * Rename `atc_local_valid_year_lower()` and
+        - Rename `atc_local_valid_year_lower()` and
           `atc_local_valid_year_upper()` to `atc_epoch_valid_year_lower()` and
           `atc_epoch_valid_year_uppper()`, consistent with AceTime library.
-        * Create `epoch.h` for features related to current epoch year, and
+        - Create `epoch.h` for features related to current epoch year, and
           epoch day converters.
-    * Upgrade TZDB from 2022e to 2022f
-        * https://mm.icann.org/pipermail/tz-announce/2022-October/000075.html
-			* Mexico will no longer observe DST except near the US border.
-			* Chihuahua moves to year-round -06 on 2022-10-30.
-			* Fiji no longer observes DST.
-			* Move links to 'backward'.
-			* In vanguard form, GMT is now a Zone and Etc/GMT a link.
-			* zic now supports links to links, and vanguard form uses this.
-			* Simplify four Ontario zones.
-			* Fix a Y2438 bug when reading TZif data.
-			* Enable 64-bit time_t on 32-bit glibc platforms.
-			* Omit large-file support when no longer needed.
-			* In C code, use some C23 features if available.
-			* Remove no-longer-needed workaround for Qt bug 53071.
-    * Add skeleton `libraries.properties` to test the C library with an
+    - Upgrade TZDB from 2022e to 2022f
+        - https://mm.icann.org/pipermail/tz-announce/2022-October/000075.html
+            - Mexico will no longer observe DST except near the US border.
+            - Chihuahua moves to year-round -06 on 2022-10-30.
+            - Fiji no longer observes DST.
+            - Move links to 'backward'.
+            - In vanguard form, GMT is now a Zone and Etc/GMT a link.
+            - zic now supports links to links, and vanguard form uses this.
+            - Simplify four Ontario zones.
+            - Fix a Y2438 bug when reading TZif data.
+            - Enable 64-bit time_t on 32-bit glibc platforms.
+            - Omit large-file support when no longer needed.
+            - In C code, use some C23 features if available.
+            - Remove no-longer-needed workaround for Qt bug 53071.
+    - Add skeleton `libraries.properties` to test the C library with an
       Arduino board.
-* 0.3.0 (2022-08-30, TZDB 2022e)
-    * Add `string_buffer.h` which implements a simple string buffer and
+- 0.3.0 (2022-08-30, TZDB 2022e)
+    - Add `string_buffer.h` which implements a simple string buffer and
       provides a collection of print functions for converting various date
       and time structures into human readable forms such as ISO8601.
-    * Add `atc_zoned_date_time_convert()` function for converting
+    - Add `atc_zoned_date_time_convert()` function for converting
       a date time from one time zone to another.
-    * Create typedefs for `struct`, and remove unnecessary `struct` keyword.
-    * Change `year` fields from `int8_t` to `int16_t`.
-    * Adjustable current epoch year
-        * Add `atc_set_local_epoch_year()` and `atc_get_local_epoch_year()`
-        * Add `atc_local_valid_year_lower()` and `atc_local_valid_year_upper()`
-            * Defines the interval `lower <= year < upper` which is guaranteed
+    - Create typedefs for `struct`, and remove unnecessary `struct` keyword.
+    - Change `year` fields from `int8_t` to `int16_t`.
+    - Adjustable current epoch year
+        - Add `atc_set_local_epoch_year()` and `atc_get_local_epoch_year()`
+        - Add `atc_local_valid_year_lower()` and `atc_local_valid_year_upper()`
+            - Defines the interval `lower <= year < upper` which is guaranteed
             to produce valid transitions.
-    * Upgrade TZDB from 2022b to 2022e
-        * 2022c
-            * https://mm.icann.org/pipermail/tz-announce/2022-August/000072.html
-                * Work around awk bug in FreeBSD, macOS, etc.
-                * Improve tzselect on intercontinental Zones.
-            * Skipped because there were no changes that affected AceTime.
-        * 2022d
-            * https://mm.icann.org/pipermail/tz-announce/2022-September/000073.html
-                * Palestine transitions are now Saturdays at 02:00.
-                * Simplify three Ukraine zones into one.
-        * 2022e
-            * https://mm.icann.org/pipermail/tz-announce/2022-October/000074.html
-                * Jordan and Syria switch from +02/+03 with DST to year-round
+    - Upgrade TZDB from 2022b to 2022e
+        - 2022c
+            - https://mm.icann.org/pipermail/tz-announce/2022-August/000072.html
+                - Work around awk bug in FreeBSD, macOS, etc.
+                - Improve tzselect on intercontinental Zones.
+            - Skipped because there were no changes that affected AceTime.
+        - 2022d
+            - https://mm.icann.org/pipermail/tz-announce/2022-September/000073.html
+                - Palestine transitions are now Saturdays at 02:00.
+                - Simplify three Ukraine zones into one.
+        - 2022e
+            - https://mm.icann.org/pipermail/tz-announce/2022-October/000074.html
+                - Jordan and Syria switch from +02/+03 with DST to year-round
                   +03.
-* 0.2.0 (2022-08-30, TZDB 2022b)
-    * Add doxygen docs. Add docstrings to various functions and structures to
+- 0.2.0 (2022-08-30, TZDB 2022b)
+    - Add doxygen docs. Add docstrings to various functions and structures to
       eliminate all doxygen warnings.
-    * Add `atc_zone_info_zone_name()` and `atc_zone_info_short_name()` functions
+    - Add `atc_zone_info_zone_name()` and `atc_zone_info_short_name()` functions
       to extract the zone name from its `AtcZoneInfo`.
-    * Bug fix: copy `AtcZoneInfo` into `AtcZonedDateTime` correctly.
-    * Change return type of various functions from `bool` (true for success)
+    - Bug fix: copy `AtcZoneInfo` into `AtcZonedDateTime` correctly.
+    - Change return type of various functions from `bool` (true for success)
       to an `int8_t` error code (0 for success). Define `kAtcErrOk` and
       `kAtcErrGeneric` constants.
-* 0.1.0 (2022-08-23, TZDB 2022b)
-    * Upgrade to TZDB 2022b.
-    * Add unit testing using bxparks/ACUnit.
-    * Add support for (symbolic) Link entries.
-    * Add `zone_registrar.c` to allow searching by zone name and zone id.`
-    * Add complete set of unit tests derived from
+- 0.1.0 (2022-08-23, TZDB 2022b)
+    - Upgrade to TZDB 2022b.
+    - Add unit testing using bxparks/ACUnit.
+    - Add support for (symbolic) Link entries.
+    - Add `zone_registrar.c` to allow searching by zone name and zone id.`
+    - Add complete set of unit tests derived from
       AceTime/ExtendedZoneProcessorTest.
-* 0.0.0 (2022-04-08, TZDB 2022a)
-    * Create project.
+- 0.0.0 (2022-04-08, TZDB 2022a)
+    - Create project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+- 0.11.2 (2024-07-24, TZDB 2024a)
     - Upgrade TZDB to 2024a
         - https://mm.icann.org/pipermail/tz-announce/2024-February/000081.html
         - "Kazakhstan unifies on UTC+5 beginning 2024-03-01. Palestine springs

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ latter documents.
 
 **Status**: Alpha-level software, not ready for public consumption.
 
-**Version**: 0.11.1 (2024-01-12, TZDB 2023d)
+**Version**: 0.11.2 (2024-07-25, TZDB 2024a)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=acetimec
-version=0.11.1
+version=0.11.2
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=Date, time, timezone library using the C language

--- a/src/acetimec.h
+++ b/src/acetimec.h
@@ -7,8 +7,8 @@
 #define ACE_TIME_C_H
 
 /* Version format: xxyyzz == "xx.yy.zz" */
-#define ACE_TIME_C_VERSION 1101
-#define ACE_TIME_C_VERSION_STRING "0.11.1"
+#define ACE_TIME_C_VERSION 1102
+#define ACE_TIME_C_VERSION_STRING "0.11.2"
 
 #include "zoneinfo/zone_info.h"
 #include "zoneinfo/zone_info_utils.h"

--- a/src/zonedb/Makefile
+++ b/src/zonedb/Makefile
@@ -8,7 +8,7 @@ zone_registry.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2023d
+TZ_VERSION := 2024a
 START_YEAR := 2000
 UNTIL_YEAR := 2200
 

--- a/src/zonedb/zone_infos.c
+++ b/src/zonedb/zone_infos.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 655
+//   Eras: 657
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,7 +49,7 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9825
+//   Eras: 9855
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37569
+//   TOTAL: 37599
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 13100
+//   Eras: 13140
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49033
+//   TOTAL: 49073
 //
 // DO NOT EDIT
 
@@ -82,7 +82,7 @@
 // ZoneContext
 //---------------------------------------------------------------------------
 
-static const char kAtcTzDatabaseVersion[] = "2023d";
+static const char kAtcTzDatabaseVersion[] = "2024a";
 
 static const char * const kAtcFragments[] = {
 /*\x00*/ NULL,
@@ -117,7 +117,7 @@ const AtcZoneContext kAtcZoneContext = {
 
 //---------------------------------------------------------------------------
 // Zones: 351
-// Eras: 655
+// Eras: 657
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -7300,7 +7300,7 @@ const AtcZoneInfo kAtcZoneAntarctica_Vostok  = {
 
 //---------------------------------------------------------------------------
 // Zone name: Asia/Almaty
-// Zone Eras: 2
+// Zone Eras: 3
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
@@ -7317,12 +7317,25 @@ static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00    -    +06
+  //             6:00    -    +06    2024 Mar  1  0:00
   {
     NULL /*zone_policy*/,
     "+06" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
+    0 /*delta_minutes*/,
+    2024 /*until_year*/,
+    3 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             5:00    -    +05
+  {
+    NULL /*zone_policy*/,
+    "+05" /*format*/,
+    1200 /*offset_code (18000/15)*/,
+    0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
     32767 /*until_year*/,
     1 /*until_month*/,
@@ -7339,7 +7352,7 @@ const AtcZoneInfo kAtcZoneAsia_Almaty  = {
   kAtcZoneNameAsia_Almaty /*name*/,
   0xa61f41fa /*zone_id*/,
   &kAtcZoneContext /*zone_context*/,
-  2 /*num_eras*/,
+  3 /*num_eras*/,
   kAtcZoneEraAsia_Almaty /*eras*/,
   NULL /*target_info*/,
 };
@@ -9672,7 +9685,7 @@ const AtcZoneInfo kAtcZoneAsia_Qatar  = {
 
 //---------------------------------------------------------------------------
 // Zone name: Asia/Qostanay
-// Zone Eras: 2
+// Zone Eras: 3
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
@@ -9689,12 +9702,25 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00    -    +06
+  //             6:00    -    +06    2024 Mar  1  0:00
   {
     NULL /*zone_policy*/,
     "+06" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
+    0 /*delta_minutes*/,
+    2024 /*until_year*/,
+    3 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             5:00    -    +05
+  {
+    NULL /*zone_policy*/,
+    "+05" /*format*/,
+    1200 /*offset_code (18000/15)*/,
+    0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
     32767 /*until_year*/,
     1 /*until_month*/,
@@ -9711,7 +9737,7 @@ const AtcZoneInfo kAtcZoneAsia_Qostanay  = {
   kAtcZoneNameAsia_Qostanay /*name*/,
   0x654fe522 /*zone_id*/,
   &kAtcZoneContext /*zone_context*/,
-  2 /*num_eras*/,
+  3 /*num_eras*/,
   kAtcZoneEraAsia_Qostanay /*eras*/,
   NULL /*target_info*/,
 };

--- a/src/zonedb/zone_infos.h
+++ b/src/zonedb/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 655
+//   Eras: 657
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,7 +49,7 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9825
+//   Eras: 9855
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37569
+//   TOTAL: 37599
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 13100
+//   Eras: 13140
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49033
+//   TOTAL: 49073
 //
 // DO NOT EDIT
 
@@ -93,7 +93,7 @@ extern const AtcZoneContext kAtcZoneContext;
 
 //---------------------------------------------------------------------------
 // Supported zones: 351
-// Supported eras: 655
+// Supported eras: 657
 //---------------------------------------------------------------------------
 
 extern const AtcZoneInfo kAtcZoneAfrica_Abidjan; // Africa/Abidjan

--- a/src/zonedb/zone_policies.c
+++ b/src/zonedb/zone_policies.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 655
+//   Eras: 657
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,7 +49,7 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9825
+//   Eras: 9855
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37569
+//   TOTAL: 37599
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 13100
+//   Eras: 13140
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49033
+//   TOTAL: 49073
 //
 // DO NOT EDIT
 
@@ -7308,25 +7308,25 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     60 /*delta_minutes*/,
     7 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2024    only    -    Apr    13    2:00    1:00    S
+  // Rule Palestine    2024    only    -    Apr    20    2:00    1:00    S
   {
     2024 /*from_year*/,
     2024 /*to_year*/,
     4 /*in_month*/,
     0 /*on_day_of_week*/,
-    13 /*on_day_of_month*/,
+    20 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     7 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2025    only    -    Apr     5    2:00    1:00    S
+  // Rule Palestine    2025    only    -    Apr    12    2:00    1:00    S
   {
     2025 /*from_year*/,
     2025 /*to_year*/,
     4 /*in_month*/,
     0 /*on_day_of_week*/,
-    5 /*on_day_of_month*/,
+    12 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7392,30 +7392,6 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2039    only    -    Oct    22    2:00    1:00    S
-  {
-    2039 /*from_year*/,
-    2039 /*to_year*/,
-    10 /*in_month*/,
-    0 /*on_day_of_week*/,
-    22 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    60 /*delta_minutes*/,
-    7 /*letterIndex ("S")*/,
-  },
-  // Rule Palestine    2039    2067    -    Oct    Sat<=30    2:00    0    -
-  {
-    2039 /*from_year*/,
-    2067 /*to_year*/,
-    10 /*in_month*/,
-    6 /*on_day_of_week*/,
-    -30 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    0 /*delta_minutes*/,
-    0 /*letterIndex ("")*/,
-  },
   // Rule Palestine    2040    only    -    Sep     1    2:00    0    -
   {
     2040 /*from_year*/,
@@ -7428,17 +7404,29 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2040    only    -    Oct    13    2:00    1:00    S
+  // Rule Palestine    2040    only    -    Oct    20    2:00    1:00    S
   {
     2040 /*from_year*/,
     2040 /*to_year*/,
     10 /*in_month*/,
     0 /*on_day_of_week*/,
-    13 /*on_day_of_month*/,
+    20 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     7 /*letterIndex ("S")*/,
+  },
+  // Rule Palestine    2040    2067    -    Oct    Sat<=30    2:00    0    -
+  {
+    2040 /*from_year*/,
+    2067 /*to_year*/,
+    10 /*in_month*/,
+    6 /*on_day_of_week*/,
+    -30 /*on_day_of_month*/,
+    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
+    480 /*at_time_code (7200/15)*/,
+    0 /*delta_minutes*/,
+    0 /*letterIndex ("")*/,
   },
   // Rule Palestine    2041    only    -    Aug    24    2:00    0    -
   {
@@ -7452,13 +7440,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2041    only    -    Sep    28    2:00    1:00    S
+  // Rule Palestine    2041    only    -    Oct     5    2:00    1:00    S
   {
     2041 /*from_year*/,
     2041 /*to_year*/,
-    9 /*in_month*/,
+    10 /*in_month*/,
     0 /*on_day_of_week*/,
-    28 /*on_day_of_month*/,
+    5 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7476,13 +7464,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2042    only    -    Sep    20    2:00    1:00    S
+  // Rule Palestine    2042    only    -    Sep    27    2:00    1:00    S
   {
     2042 /*from_year*/,
     2042 /*to_year*/,
     9 /*in_month*/,
     0 /*on_day_of_week*/,
-    20 /*on_day_of_month*/,
+    27 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7500,13 +7488,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2043    only    -    Sep    12    2:00    1:00    S
+  // Rule Palestine    2043    only    -    Sep    19    2:00    1:00    S
   {
     2043 /*from_year*/,
     2043 /*to_year*/,
     9 /*in_month*/,
     0 /*on_day_of_week*/,
-    12 /*on_day_of_month*/,
+    19 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7524,13 +7512,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2044    only    -    Aug    27    2:00    1:00    S
+  // Rule Palestine    2044    only    -    Sep     3    2:00    1:00    S
   {
     2044 /*from_year*/,
     2044 /*to_year*/,
-    8 /*in_month*/,
+    9 /*in_month*/,
     0 /*on_day_of_week*/,
-    27 /*on_day_of_month*/,
+    3 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7548,13 +7536,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2045    only    -    Aug    19    2:00    1:00    S
+  // Rule Palestine    2045    only    -    Aug    26    2:00    1:00    S
   {
     2045 /*from_year*/,
     2045 /*to_year*/,
     8 /*in_month*/,
     0 /*on_day_of_week*/,
-    19 /*on_day_of_month*/,
+    26 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7572,13 +7560,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2046    only    -    Aug    11    2:00    1:00    S
+  // Rule Palestine    2046    only    -    Aug    18    2:00    1:00    S
   {
     2046 /*from_year*/,
     2046 /*to_year*/,
     8 /*in_month*/,
     0 /*on_day_of_week*/,
-    11 /*on_day_of_month*/,
+    18 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7596,13 +7584,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2047    only    -    Jul    27    2:00    1:00    S
+  // Rule Palestine    2047    only    -    Aug     3    2:00    1:00    S
   {
     2047 /*from_year*/,
     2047 /*to_year*/,
-    7 /*in_month*/,
+    8 /*in_month*/,
     0 /*on_day_of_week*/,
-    27 /*on_day_of_month*/,
+    3 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7620,13 +7608,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2048    only    -    Jul    18    2:00    1:00    S
+  // Rule Palestine    2048    only    -    Jul    25    2:00    1:00    S
   {
     2048 /*from_year*/,
     2048 /*to_year*/,
     7 /*in_month*/,
     0 /*on_day_of_week*/,
-    18 /*on_day_of_month*/,
+    25 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7644,13 +7632,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2049    only    -    Jul     3    2:00    1:00    S
+  // Rule Palestine    2049    only    -    Jul    10    2:00    1:00    S
   {
     2049 /*from_year*/,
     2049 /*to_year*/,
     7 /*in_month*/,
     0 /*on_day_of_week*/,
-    3 /*on_day_of_month*/,
+    10 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7668,13 +7656,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2050    only    -    Jun    25    2:00    1:00    S
+  // Rule Palestine    2050    only    -    Jul     2    2:00    1:00    S
   {
     2050 /*from_year*/,
     2050 /*to_year*/,
-    6 /*in_month*/,
+    7 /*in_month*/,
     0 /*on_day_of_week*/,
-    25 /*on_day_of_month*/,
+    2 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7692,13 +7680,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2051    only    -    Jun    17    2:00    1:00    S
+  // Rule Palestine    2051    only    -    Jun    24    2:00    1:00    S
   {
     2051 /*from_year*/,
     2051 /*to_year*/,
     6 /*in_month*/,
     0 /*on_day_of_week*/,
-    17 /*on_day_of_month*/,
+    24 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7716,13 +7704,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2052    only    -    Jun     1    2:00    1:00    S
+  // Rule Palestine    2052    only    -    Jun     8    2:00    1:00    S
   {
     2052 /*from_year*/,
     2052 /*to_year*/,
     6 /*in_month*/,
     0 /*on_day_of_week*/,
-    1 /*on_day_of_month*/,
+    8 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7740,13 +7728,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2053    only    -    May    24    2:00    1:00    S
+  // Rule Palestine    2053    only    -    May    31    2:00    1:00    S
   {
     2053 /*from_year*/,
     2053 /*to_year*/,
     5 /*in_month*/,
     0 /*on_day_of_week*/,
-    24 /*on_day_of_month*/,
+    31 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7764,57 +7752,69 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2054    only    -    May    16    2:00    1:00    S
+  // Rule Palestine    2054    only    -    May    23    2:00    1:00    S
   {
     2054 /*from_year*/,
     2054 /*to_year*/,
     5 /*in_month*/,
     0 /*on_day_of_week*/,
-    16 /*on_day_of_month*/,
+    23 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     7 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2055    only    -    May     1    2:00    1:00    S
+  // Rule Palestine    2055    only    -    May     8    2:00    1:00    S
   {
     2055 /*from_year*/,
     2055 /*to_year*/,
     5 /*in_month*/,
     0 /*on_day_of_week*/,
-    1 /*on_day_of_month*/,
+    8 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     7 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2056    only    -    Apr    22    2:00    1:00    S
+  // Rule Palestine    2056    only    -    Apr    29    2:00    1:00    S
   {
     2056 /*from_year*/,
     2056 /*to_year*/,
     4 /*in_month*/,
     0 /*on_day_of_week*/,
-    22 /*on_day_of_month*/,
+    29 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     7 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2057    only    -    Apr     7    2:00    1:00    S
+  // Rule Palestine    2057    only    -    Apr    14    2:00    1:00    S
   {
     2057 /*from_year*/,
     2057 /*to_year*/,
     4 /*in_month*/,
     0 /*on_day_of_week*/,
-    7 /*on_day_of_month*/,
+    14 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     7 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2058    max    -    Mar    Sat<=30    2:00    1:00    S
+  // Rule Palestine    2058    only    -    Apr     6    2:00    1:00    S
   {
     2058 /*from_year*/,
+    2058 /*to_year*/,
+    4 /*in_month*/,
+    0 /*on_day_of_week*/,
+    6 /*on_day_of_month*/,
+    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
+    480 /*at_time_code (7200/15)*/,
+    60 /*delta_minutes*/,
+    7 /*letterIndex ("S")*/,
+  },
+  // Rule Palestine    2059    max    -    Mar    Sat<=30    2:00    1:00    S
+  {
+    2059 /*from_year*/,
     32766 /*to_year*/,
     3 /*in_month*/,
     6 /*on_day_of_week*/,
@@ -7884,13 +7884,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2072    only    -    Oct    15    2:00    1:00    S
+  // Rule Palestine    2072    only    -    Oct    22    2:00    1:00    S
   {
     2072 /*from_year*/,
     2072 /*to_year*/,
     10 /*in_month*/,
     0 /*on_day_of_week*/,
-    15 /*on_day_of_month*/,
+    22 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7920,13 +7920,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2073    only    -    Oct     7    2:00    1:00    S
+  // Rule Palestine    2073    only    -    Oct    14    2:00    1:00    S
   {
     2073 /*from_year*/,
     2073 /*to_year*/,
     10 /*in_month*/,
     0 /*on_day_of_week*/,
-    7 /*on_day_of_month*/,
+    14 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7944,13 +7944,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2074    only    -    Sep    29    2:00    1:00    S
+  // Rule Palestine    2074    only    -    Oct     6    2:00    1:00    S
   {
     2074 /*from_year*/,
     2074 /*to_year*/,
-    9 /*in_month*/,
+    10 /*in_month*/,
     0 /*on_day_of_week*/,
-    29 /*on_day_of_month*/,
+    6 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7968,13 +7968,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2075    only    -    Sep    14    2:00    1:00    S
+  // Rule Palestine    2075    only    -    Sep    21    2:00    1:00    S
   {
     2075 /*from_year*/,
     2075 /*to_year*/,
     9 /*in_month*/,
     0 /*on_day_of_week*/,
-    14 /*on_day_of_month*/,
+    21 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -7992,13 +7992,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2076    only    -    Sep     5    2:00    1:00    S
+  // Rule Palestine    2076    only    -    Sep    12    2:00    1:00    S
   {
     2076 /*from_year*/,
     2076 /*to_year*/,
     9 /*in_month*/,
     0 /*on_day_of_week*/,
-    5 /*on_day_of_month*/,
+    12 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -8016,13 +8016,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2077    only    -    Aug    28    2:00    1:00    S
+  // Rule Palestine    2077    only    -    Sep     4    2:00    1:00    S
   {
     2077 /*from_year*/,
     2077 /*to_year*/,
-    8 /*in_month*/,
+    9 /*in_month*/,
     0 /*on_day_of_week*/,
-    28 /*on_day_of_month*/,
+    4 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -8040,13 +8040,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2078    only    -    Aug    13    2:00    1:00    S
+  // Rule Palestine    2078    only    -    Aug    20    2:00    1:00    S
   {
     2078 /*from_year*/,
     2078 /*to_year*/,
     8 /*in_month*/,
     0 /*on_day_of_week*/,
-    13 /*on_day_of_month*/,
+    20 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -8064,13 +8064,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2079    only    -    Aug     5    2:00    1:00    S
+  // Rule Palestine    2079    only    -    Aug    12    2:00    1:00    S
   {
     2079 /*from_year*/,
     2079 /*to_year*/,
     8 /*in_month*/,
     0 /*on_day_of_week*/,
-    5 /*on_day_of_month*/,
+    12 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -8088,13 +8088,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2080    only    -    Jul    20    2:00    1:00    S
+  // Rule Palestine    2080    only    -    Jul    27    2:00    1:00    S
   {
     2080 /*from_year*/,
     2080 /*to_year*/,
     7 /*in_month*/,
     0 /*on_day_of_week*/,
-    20 /*on_day_of_month*/,
+    27 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -8112,13 +8112,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2081    only    -    Jul    12    2:00    1:00    S
+  // Rule Palestine    2081    only    -    Jul    19    2:00    1:00    S
   {
     2081 /*from_year*/,
     2081 /*to_year*/,
     7 /*in_month*/,
     0 /*on_day_of_week*/,
-    12 /*on_day_of_month*/,
+    19 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -8136,13 +8136,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2082    only    -    Jul     4    2:00    1:00    S
+  // Rule Palestine    2082    only    -    Jul    11    2:00    1:00    S
   {
     2082 /*from_year*/,
     2082 /*to_year*/,
     7 /*in_month*/,
     0 /*on_day_of_week*/,
-    4 /*on_day_of_month*/,
+    11 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -8160,13 +8160,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2083    only    -    Jun    19    2:00    1:00    S
+  // Rule Palestine    2083    only    -    Jun    26    2:00    1:00    S
   {
     2083 /*from_year*/,
     2083 /*to_year*/,
     6 /*in_month*/,
     0 /*on_day_of_week*/,
-    19 /*on_day_of_month*/,
+    26 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -8184,13 +8184,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2084    only    -    Jun    10    2:00    1:00    S
+  // Rule Palestine    2084    only    -    Jun    17    2:00    1:00    S
   {
     2084 /*from_year*/,
     2084 /*to_year*/,
     6 /*in_month*/,
     0 /*on_day_of_week*/,
-    10 /*on_day_of_month*/,
+    17 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -8208,13 +8208,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2085    only    -    Jun     2    2:00    1:00    S
+  // Rule Palestine    2085    only    -    Jun     9    2:00    1:00    S
   {
     2085 /*from_year*/,
     2085 /*to_year*/,
     6 /*in_month*/,
     0 /*on_day_of_week*/,
-    2 /*on_day_of_month*/,
+    9 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -8232,13 +8232,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2086    only    -    May    18    2:00    1:00    S
+  // Rule Palestine    2086    only    -    May    25    2:00    1:00    S
   {
     2086 /*from_year*/,
     2086 /*to_year*/,
     5 /*in_month*/,
     0 /*on_day_of_week*/,
-    18 /*on_day_of_month*/,
+    25 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,

--- a/src/zonedb/zone_policies.h
+++ b/src/zonedb/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 655
+//   Eras: 657
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,7 +49,7 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9825
+//   Eras: 9855
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37569
+//   TOTAL: 37599
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 13100
+//   Eras: 13140
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49033
+//   TOTAL: 49073
 //
 // DO NOT EDIT
 

--- a/src/zonedb/zone_registry.c
+++ b/src/zonedb/zone_registry.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 655
+//   Eras: 657
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,7 +49,7 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9825
+//   Eras: 9855
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37569
+//   TOTAL: 37599
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 13100
+//   Eras: 13140
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49033
+//   TOTAL: 49073
 //
 // DO NOT EDIT
 

--- a/src/zonedb/zone_registry.h
+++ b/src/zonedb/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,7 +41,7 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 655
+//   Eras: 657
 //   Policies: 83
 //   Rules: 735
 //
@@ -49,7 +49,7 @@
 //   Context: 16
 //   Rules: 8820
 //   Policies: 249
-//   Eras: 9825
+//   Eras: 9855
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37569
+//   TOTAL: 37599
 //
 // Memory (32-bits):
 //   Context: 24
 //   Rules: 8820
 //   Policies: 664
-//   Eras: 13100
+//   Eras: 13140
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49033
+//   TOTAL: 49073
 //
 // DO NOT EDIT
 

--- a/src/zonedball/Makefile
+++ b/src/zonedball/Makefile
@@ -8,7 +8,7 @@ zone_registry.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2023d
+TZ_VERSION := 2024a
 START_YEAR := 1800
 UNTIL_YEAR := 2200
 

--- a/src/zonedball/zone_infos.c
+++ b/src/zonedball/zone_infos.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,15 +41,15 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1961
+//   Eras: 1963
 //   Policies: 134
-//   Rules: 2238
+//   Rules: 2234
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 402
-//   Eras: 29415
+//   Eras: 29445
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75897
+//   TOTAL: 75879
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 1072
-//   Eras: 39220
+//   Eras: 39260
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94184
+//   TOTAL: 94176
 //
 // DO NOT EDIT
 
@@ -82,7 +82,7 @@
 // ZoneContext
 //---------------------------------------------------------------------------
 
-static const char kAtcTzDatabaseVersion[] = "2023d";
+static const char kAtcTzDatabaseVersion[] = "2024a";
 
 static const char * const kAtcFragments[] = {
 /*\x00*/ NULL,
@@ -136,7 +136,7 @@ const AtcZoneContext kAtcAllZoneContext = {
 
 //---------------------------------------------------------------------------
 // Zones: 351
-// Eras: 1961
+// Eras: 1963
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -145,7 +145,7 @@ const AtcZoneContext kAtcAllZoneContext = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAfrica_Abidjan[]  = {
-  // -0:16:08 - LMT 1912
+  // -0:16:08 - LMT 1912 Jan 1
   {
     NULL /*zone_policy*/,
     "LMT" /*format*/,
@@ -1244,7 +1244,7 @@ const AtcZoneInfo kAtcAllZoneAfrica_Nairobi  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAfrica_Ndjamena[]  = {
-  // 1:00:12 - LMT 1912
+  // 1:00:12 - LMT 1912 Jan 1
   {
     NULL /*zone_policy*/,
     "LMT" /*format*/,
@@ -5141,7 +5141,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Caracas  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Cayenne[]  = {
-  // -3:29:20 - LMT 1911 Jul
+  // -3:29:20 - LMT 1911 Jul 1
   {
     NULL /*zone_policy*/,
     "LMT" /*format*/,
@@ -9694,7 +9694,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Martinique[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:04:20 -    FFMT    1911 May
+  //             -4:04:20 -    FFMT    1911 May  1
   {
     NULL /*zone_policy*/,
     "FFMT" /*format*/,
@@ -10393,7 +10393,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Mexico_City  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Miquelon[]  = {
-  // -3:44:40 - LMT 1911 May 15
+  // -3:44:40 - LMT 1911 Jun 15
   {
     NULL /*zone_policy*/,
     "LMT" /*format*/,
@@ -10401,7 +10401,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Miquelon[]  = {
     5 /*offset_remainder (-13480%15)*/,
     0 /*delta_minutes*/,
     1911 /*until_year*/,
-    5 /*until_month*/,
+    6 /*until_month*/,
     15 /*until_day*/,
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
@@ -15158,7 +15158,7 @@ const AtcZoneInfo kAtcAllZoneAntarctica_Vostok  = {
 
 //---------------------------------------------------------------------------
 // Zone name: Asia/Almaty
-// Zone Eras: 6
+// Zone Eras: 7
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
@@ -15227,12 +15227,25 @@ static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00    -    +06
+  //             6:00    -    +06    2024 Mar  1  0:00
   {
     NULL /*zone_policy*/,
     "+06" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
+    0 /*delta_minutes*/,
+    2024 /*until_year*/,
+    3 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             5:00    -    +05
+  {
+    NULL /*zone_policy*/,
+    "+05" /*format*/,
+    1200 /*offset_code (18000/15)*/,
+    0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
     32767 /*until_year*/,
     1 /*until_month*/,
@@ -15249,7 +15262,7 @@ const AtcZoneInfo kAtcAllZoneAsia_Almaty  = {
   kAtcZoneNameAsia_Almaty /*name*/,
   0xa61f41fa /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  6 /*num_eras*/,
+  7 /*num_eras*/,
   kAtcZoneEraAsia_Almaty /*eras*/,
   NULL /*target_info*/,
 };
@@ -17605,7 +17618,7 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     5520 /*until_time_code (82800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09    1945 Sep  2
+  //             9:00    -    +09    1945 Sep  1 24:00
   {
     NULL /*zone_policy*/,
     "+09" /*format*/,
@@ -17614,8 +17627,8 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     0 /*delta_minutes*/,
     1945 /*until_year*/,
     9 /*until_month*/,
-    2 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
+    1 /*until_day*/,
+    5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             7:00    -    +07    1947 Apr  1
@@ -17631,7 +17644,7 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00    -    +08    1955 Jul  1
+  //             8:00    -    +08    1955 Jul  1 01:00
   {
     NULL /*zone_policy*/,
     "+08" /*format*/,
@@ -17641,7 +17654,7 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     1955 /*until_year*/,
     7 /*until_month*/,
     1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
+    240 /*until_time_code (3600/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             7:00    -    +07    1959 Dec 31 23:00
@@ -20260,7 +20273,7 @@ const AtcZoneInfo kAtcAllZoneAsia_Qatar  = {
 
 //---------------------------------------------------------------------------
 // Zone name: Asia/Qostanay
-// Zone Eras: 9
+// Zone Eras: 10
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
@@ -20368,12 +20381,25 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00    -    +06
+  //             6:00    -    +06    2024 Mar  1  0:00
   {
     NULL /*zone_policy*/,
     "+06" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
+    0 /*delta_minutes*/,
+    2024 /*until_year*/,
+    3 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             5:00    -    +05
+  {
+    NULL /*zone_policy*/,
+    "+05" /*format*/,
+    1200 /*offset_code (18000/15)*/,
+    0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
     32767 /*until_year*/,
     1 /*until_month*/,
@@ -20390,7 +20416,7 @@ const AtcZoneInfo kAtcAllZoneAsia_Qostanay  = {
   kAtcZoneNameAsia_Qostanay /*name*/,
   0x654fe522 /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  9 /*num_eras*/,
+  10 /*num_eras*/,
   kAtcZoneEraAsia_Qostanay /*eras*/,
   NULL /*target_info*/,
 };
@@ -31126,7 +31152,7 @@ const AtcZoneInfo kAtcAllZonePacific_Galapagos  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Gambier[]  = {
-  // -8:59:48 - LMT 1912 Oct
+  // -8:59:48 - LMT 1912 Oct 1
   {
     NULL /*zone_policy*/,
     "LMT" /*format*/,
@@ -31172,7 +31198,7 @@ const AtcZoneInfo kAtcAllZonePacific_Gambier  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Guadalcanal[]  = {
-  // 10:39:48 - LMT 1912 Oct
+  // 10:39:48 - LMT 1912 Oct 1
   {
     NULL /*zone_policy*/,
     "LMT" /*format*/,
@@ -31806,7 +31832,7 @@ const AtcZoneInfo kAtcAllZonePacific_Kwajalein  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Marquesas[]  = {
-  // -9:18:00 - LMT 1912 Oct
+  // -9:18:00 - LMT 1912 Oct 1
   {
     NULL /*zone_policy*/,
     "LMT" /*format*/,
@@ -32461,7 +32487,7 @@ const AtcZoneInfo kAtcAllZonePacific_Rarotonga  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Tahiti[]  = {
-  // -9:58:16 - LMT 1912 Oct
+  // -9:58:16 - LMT 1912 Oct 1
   {
     NULL /*zone_policy*/,
     "LMT" /*format*/,

--- a/src/zonedball/zone_infos.h
+++ b/src/zonedball/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,15 +41,15 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1961
+//   Eras: 1963
 //   Policies: 134
-//   Rules: 2238
+//   Rules: 2234
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 402
-//   Eras: 29415
+//   Eras: 29445
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75897
+//   TOTAL: 75879
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 1072
-//   Eras: 39220
+//   Eras: 39260
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94184
+//   TOTAL: 94176
 //
 // DO NOT EDIT
 
@@ -93,7 +93,7 @@ extern const AtcZoneContext kAtcAllZoneContext;
 
 //---------------------------------------------------------------------------
 // Supported zones: 351
-// Supported eras: 1961
+// Supported eras: 1963
 //---------------------------------------------------------------------------
 
 extern const AtcZoneInfo kAtcAllZoneAfrica_Abidjan; // Africa/Abidjan

--- a/src/zonedball/zone_policies.c
+++ b/src/zonedball/zone_policies.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,15 +41,15 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1961
+//   Eras: 1963
 //   Policies: 134
-//   Rules: 2238
+//   Rules: 2234
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 402
-//   Eras: 29415
+//   Eras: 29445
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75897
+//   TOTAL: 75879
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 1072
-//   Eras: 39220
+//   Eras: 39260
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94184
+//   TOTAL: 94176
 //
 // DO NOT EDIT
 
@@ -79,7 +79,7 @@
 
 //---------------------------------------------------------------------------
 // Policies: 134
-// Rules: 2238
+// Rules: 2234
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -19012,25 +19012,25 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2024    only    -    Apr    13    2:00    1:00    S
+  // Rule Palestine    2024    only    -    Apr    20    2:00    1:00    S
   {
     2024 /*from_year*/,
     2024 /*to_year*/,
     4 /*in_month*/,
     0 /*on_day_of_week*/,
-    13 /*on_day_of_month*/,
+    20 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2025    only    -    Apr     5    2:00    1:00    S
+  // Rule Palestine    2025    only    -    Apr    12    2:00    1:00    S
   {
     2025 /*from_year*/,
     2025 /*to_year*/,
     4 /*in_month*/,
     0 /*on_day_of_week*/,
-    5 /*on_day_of_month*/,
+    12 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19096,30 +19096,6 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2039    only    -    Oct    22    2:00    1:00    S
-  {
-    2039 /*from_year*/,
-    2039 /*to_year*/,
-    10 /*in_month*/,
-    0 /*on_day_of_week*/,
-    22 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    60 /*delta_minutes*/,
-    25 /*letterIndex ("S")*/,
-  },
-  // Rule Palestine    2039    2067    -    Oct    Sat<=30    2:00    0    -
-  {
-    2039 /*from_year*/,
-    2067 /*to_year*/,
-    10 /*in_month*/,
-    6 /*on_day_of_week*/,
-    -30 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    0 /*delta_minutes*/,
-    0 /*letterIndex ("")*/,
-  },
   // Rule Palestine    2040    only    -    Sep     1    2:00    0    -
   {
     2040 /*from_year*/,
@@ -19132,17 +19108,29 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2040    only    -    Oct    13    2:00    1:00    S
+  // Rule Palestine    2040    only    -    Oct    20    2:00    1:00    S
   {
     2040 /*from_year*/,
     2040 /*to_year*/,
     10 /*in_month*/,
     0 /*on_day_of_week*/,
-    13 /*on_day_of_month*/,
+    20 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
+  },
+  // Rule Palestine    2040    2067    -    Oct    Sat<=30    2:00    0    -
+  {
+    2040 /*from_year*/,
+    2067 /*to_year*/,
+    10 /*in_month*/,
+    6 /*on_day_of_week*/,
+    -30 /*on_day_of_month*/,
+    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
+    480 /*at_time_code (7200/15)*/,
+    0 /*delta_minutes*/,
+    0 /*letterIndex ("")*/,
   },
   // Rule Palestine    2041    only    -    Aug    24    2:00    0    -
   {
@@ -19156,13 +19144,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2041    only    -    Sep    28    2:00    1:00    S
+  // Rule Palestine    2041    only    -    Oct     5    2:00    1:00    S
   {
     2041 /*from_year*/,
     2041 /*to_year*/,
-    9 /*in_month*/,
+    10 /*in_month*/,
     0 /*on_day_of_week*/,
-    28 /*on_day_of_month*/,
+    5 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19180,13 +19168,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2042    only    -    Sep    20    2:00    1:00    S
+  // Rule Palestine    2042    only    -    Sep    27    2:00    1:00    S
   {
     2042 /*from_year*/,
     2042 /*to_year*/,
     9 /*in_month*/,
     0 /*on_day_of_week*/,
-    20 /*on_day_of_month*/,
+    27 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19204,13 +19192,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2043    only    -    Sep    12    2:00    1:00    S
+  // Rule Palestine    2043    only    -    Sep    19    2:00    1:00    S
   {
     2043 /*from_year*/,
     2043 /*to_year*/,
     9 /*in_month*/,
     0 /*on_day_of_week*/,
-    12 /*on_day_of_month*/,
+    19 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19228,13 +19216,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2044    only    -    Aug    27    2:00    1:00    S
+  // Rule Palestine    2044    only    -    Sep     3    2:00    1:00    S
   {
     2044 /*from_year*/,
     2044 /*to_year*/,
-    8 /*in_month*/,
+    9 /*in_month*/,
     0 /*on_day_of_week*/,
-    27 /*on_day_of_month*/,
+    3 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19252,13 +19240,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2045    only    -    Aug    19    2:00    1:00    S
+  // Rule Palestine    2045    only    -    Aug    26    2:00    1:00    S
   {
     2045 /*from_year*/,
     2045 /*to_year*/,
     8 /*in_month*/,
     0 /*on_day_of_week*/,
-    19 /*on_day_of_month*/,
+    26 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19276,13 +19264,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2046    only    -    Aug    11    2:00    1:00    S
+  // Rule Palestine    2046    only    -    Aug    18    2:00    1:00    S
   {
     2046 /*from_year*/,
     2046 /*to_year*/,
     8 /*in_month*/,
     0 /*on_day_of_week*/,
-    11 /*on_day_of_month*/,
+    18 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19300,13 +19288,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2047    only    -    Jul    27    2:00    1:00    S
+  // Rule Palestine    2047    only    -    Aug     3    2:00    1:00    S
   {
     2047 /*from_year*/,
     2047 /*to_year*/,
-    7 /*in_month*/,
+    8 /*in_month*/,
     0 /*on_day_of_week*/,
-    27 /*on_day_of_month*/,
+    3 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19324,13 +19312,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2048    only    -    Jul    18    2:00    1:00    S
+  // Rule Palestine    2048    only    -    Jul    25    2:00    1:00    S
   {
     2048 /*from_year*/,
     2048 /*to_year*/,
     7 /*in_month*/,
     0 /*on_day_of_week*/,
-    18 /*on_day_of_month*/,
+    25 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19348,13 +19336,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2049    only    -    Jul     3    2:00    1:00    S
+  // Rule Palestine    2049    only    -    Jul    10    2:00    1:00    S
   {
     2049 /*from_year*/,
     2049 /*to_year*/,
     7 /*in_month*/,
     0 /*on_day_of_week*/,
-    3 /*on_day_of_month*/,
+    10 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19372,13 +19360,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2050    only    -    Jun    25    2:00    1:00    S
+  // Rule Palestine    2050    only    -    Jul     2    2:00    1:00    S
   {
     2050 /*from_year*/,
     2050 /*to_year*/,
-    6 /*in_month*/,
+    7 /*in_month*/,
     0 /*on_day_of_week*/,
-    25 /*on_day_of_month*/,
+    2 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19396,13 +19384,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2051    only    -    Jun    17    2:00    1:00    S
+  // Rule Palestine    2051    only    -    Jun    24    2:00    1:00    S
   {
     2051 /*from_year*/,
     2051 /*to_year*/,
     6 /*in_month*/,
     0 /*on_day_of_week*/,
-    17 /*on_day_of_month*/,
+    24 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19420,13 +19408,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2052    only    -    Jun     1    2:00    1:00    S
+  // Rule Palestine    2052    only    -    Jun     8    2:00    1:00    S
   {
     2052 /*from_year*/,
     2052 /*to_year*/,
     6 /*in_month*/,
     0 /*on_day_of_week*/,
-    1 /*on_day_of_month*/,
+    8 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19444,13 +19432,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2053    only    -    May    24    2:00    1:00    S
+  // Rule Palestine    2053    only    -    May    31    2:00    1:00    S
   {
     2053 /*from_year*/,
     2053 /*to_year*/,
     5 /*in_month*/,
     0 /*on_day_of_week*/,
-    24 /*on_day_of_month*/,
+    31 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19468,57 +19456,69 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2054    only    -    May    16    2:00    1:00    S
+  // Rule Palestine    2054    only    -    May    23    2:00    1:00    S
   {
     2054 /*from_year*/,
     2054 /*to_year*/,
     5 /*in_month*/,
     0 /*on_day_of_week*/,
-    16 /*on_day_of_month*/,
+    23 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2055    only    -    May     1    2:00    1:00    S
+  // Rule Palestine    2055    only    -    May     8    2:00    1:00    S
   {
     2055 /*from_year*/,
     2055 /*to_year*/,
     5 /*in_month*/,
     0 /*on_day_of_week*/,
-    1 /*on_day_of_month*/,
+    8 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2056    only    -    Apr    22    2:00    1:00    S
+  // Rule Palestine    2056    only    -    Apr    29    2:00    1:00    S
   {
     2056 /*from_year*/,
     2056 /*to_year*/,
     4 /*in_month*/,
     0 /*on_day_of_week*/,
-    22 /*on_day_of_month*/,
+    29 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2057    only    -    Apr     7    2:00    1:00    S
+  // Rule Palestine    2057    only    -    Apr    14    2:00    1:00    S
   {
     2057 /*from_year*/,
     2057 /*to_year*/,
     4 /*in_month*/,
     0 /*on_day_of_week*/,
-    7 /*on_day_of_month*/,
+    14 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule Palestine    2058    max    -    Mar    Sat<=30    2:00    1:00    S
+  // Rule Palestine    2058    only    -    Apr     6    2:00    1:00    S
   {
     2058 /*from_year*/,
+    2058 /*to_year*/,
+    4 /*in_month*/,
+    0 /*on_day_of_week*/,
+    6 /*on_day_of_month*/,
+    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
+    480 /*at_time_code (7200/15)*/,
+    60 /*delta_minutes*/,
+    25 /*letterIndex ("S")*/,
+  },
+  // Rule Palestine    2059    max    -    Mar    Sat<=30    2:00    1:00    S
+  {
+    2059 /*from_year*/,
     32766 /*to_year*/,
     3 /*in_month*/,
     6 /*on_day_of_week*/,
@@ -19588,13 +19588,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2072    only    -    Oct    15    2:00    1:00    S
+  // Rule Palestine    2072    only    -    Oct    22    2:00    1:00    S
   {
     2072 /*from_year*/,
     2072 /*to_year*/,
     10 /*in_month*/,
     0 /*on_day_of_week*/,
-    15 /*on_day_of_month*/,
+    22 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19624,13 +19624,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2073    only    -    Oct     7    2:00    1:00    S
+  // Rule Palestine    2073    only    -    Oct    14    2:00    1:00    S
   {
     2073 /*from_year*/,
     2073 /*to_year*/,
     10 /*in_month*/,
     0 /*on_day_of_week*/,
-    7 /*on_day_of_month*/,
+    14 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19648,13 +19648,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2074    only    -    Sep    29    2:00    1:00    S
+  // Rule Palestine    2074    only    -    Oct     6    2:00    1:00    S
   {
     2074 /*from_year*/,
     2074 /*to_year*/,
-    9 /*in_month*/,
+    10 /*in_month*/,
     0 /*on_day_of_week*/,
-    29 /*on_day_of_month*/,
+    6 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19672,13 +19672,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2075    only    -    Sep    14    2:00    1:00    S
+  // Rule Palestine    2075    only    -    Sep    21    2:00    1:00    S
   {
     2075 /*from_year*/,
     2075 /*to_year*/,
     9 /*in_month*/,
     0 /*on_day_of_week*/,
-    14 /*on_day_of_month*/,
+    21 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19696,13 +19696,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2076    only    -    Sep     5    2:00    1:00    S
+  // Rule Palestine    2076    only    -    Sep    12    2:00    1:00    S
   {
     2076 /*from_year*/,
     2076 /*to_year*/,
     9 /*in_month*/,
     0 /*on_day_of_week*/,
-    5 /*on_day_of_month*/,
+    12 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19720,13 +19720,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2077    only    -    Aug    28    2:00    1:00    S
+  // Rule Palestine    2077    only    -    Sep     4    2:00    1:00    S
   {
     2077 /*from_year*/,
     2077 /*to_year*/,
-    8 /*in_month*/,
+    9 /*in_month*/,
     0 /*on_day_of_week*/,
-    28 /*on_day_of_month*/,
+    4 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19744,13 +19744,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2078    only    -    Aug    13    2:00    1:00    S
+  // Rule Palestine    2078    only    -    Aug    20    2:00    1:00    S
   {
     2078 /*from_year*/,
     2078 /*to_year*/,
     8 /*in_month*/,
     0 /*on_day_of_week*/,
-    13 /*on_day_of_month*/,
+    20 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19768,13 +19768,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2079    only    -    Aug     5    2:00    1:00    S
+  // Rule Palestine    2079    only    -    Aug    12    2:00    1:00    S
   {
     2079 /*from_year*/,
     2079 /*to_year*/,
     8 /*in_month*/,
     0 /*on_day_of_week*/,
-    5 /*on_day_of_month*/,
+    12 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19792,13 +19792,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2080    only    -    Jul    20    2:00    1:00    S
+  // Rule Palestine    2080    only    -    Jul    27    2:00    1:00    S
   {
     2080 /*from_year*/,
     2080 /*to_year*/,
     7 /*in_month*/,
     0 /*on_day_of_week*/,
-    20 /*on_day_of_month*/,
+    27 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19816,13 +19816,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2081    only    -    Jul    12    2:00    1:00    S
+  // Rule Palestine    2081    only    -    Jul    19    2:00    1:00    S
   {
     2081 /*from_year*/,
     2081 /*to_year*/,
     7 /*in_month*/,
     0 /*on_day_of_week*/,
-    12 /*on_day_of_month*/,
+    19 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19840,13 +19840,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2082    only    -    Jul     4    2:00    1:00    S
+  // Rule Palestine    2082    only    -    Jul    11    2:00    1:00    S
   {
     2082 /*from_year*/,
     2082 /*to_year*/,
     7 /*in_month*/,
     0 /*on_day_of_week*/,
-    4 /*on_day_of_month*/,
+    11 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19864,13 +19864,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2083    only    -    Jun    19    2:00    1:00    S
+  // Rule Palestine    2083    only    -    Jun    26    2:00    1:00    S
   {
     2083 /*from_year*/,
     2083 /*to_year*/,
     6 /*in_month*/,
     0 /*on_day_of_week*/,
-    19 /*on_day_of_month*/,
+    26 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19888,13 +19888,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2084    only    -    Jun    10    2:00    1:00    S
+  // Rule Palestine    2084    only    -    Jun    17    2:00    1:00    S
   {
     2084 /*from_year*/,
     2084 /*to_year*/,
     6 /*in_month*/,
     0 /*on_day_of_week*/,
-    10 /*on_day_of_month*/,
+    17 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19912,13 +19912,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2085    only    -    Jun     2    2:00    1:00    S
+  // Rule Palestine    2085    only    -    Jun     9    2:00    1:00    S
   {
     2085 /*from_year*/,
     2085 /*to_year*/,
     6 /*in_month*/,
     0 /*on_day_of_week*/,
-    2 /*on_day_of_month*/,
+    9 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -19936,13 +19936,13 @@ static const AtcZoneRule kAtcZoneRulesPalestine[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule Palestine    2086    only    -    May    18    2:00    1:00    S
+  // Rule Palestine    2086    only    -    May    25    2:00    1:00    S
   {
     2086 /*from_year*/,
     2086 /*to_year*/,
     5 /*in_month*/,
     0 /*on_day_of_week*/,
-    18 /*on_day_of_month*/,
+    25 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
     480 /*at_time_code (7200/15)*/,
     60 /*delta_minutes*/,
@@ -24840,7 +24840,7 @@ const AtcZonePolicy kAtcAllZonePolicyTonga  = {
 
 //---------------------------------------------------------------------------
 // Policy name: Toronto
-// Rules: 23
+// Rules: 19
 //---------------------------------------------------------------------------
 
 static const AtcZoneRule kAtcZoneRulesToronto[]  = {
@@ -25012,69 +25012,21 @@ static const AtcZoneRule kAtcZoneRulesToronto[]  = {
     0 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule    Toronto    1945    1946    -    Sep    lastSun    2:00    0    S
+  // Rule    Toronto    1945    1948    -    Sep    lastSun    2:00    0    S
   {
     1945 /*from_year*/,
-    1946 /*to_year*/,
-    9 /*in_month*/,
-    7 /*on_day_of_week*/,
-    0 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    0 /*delta_minutes*/,
-    25 /*letterIndex ("S")*/,
-  },
-  // Rule    Toronto    1946    only    -    Apr    lastSun    2:00    1:00    D
-  {
-    1946 /*from_year*/,
-    1946 /*to_year*/,
-    4 /*in_month*/,
-    7 /*on_day_of_week*/,
-    0 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    60 /*delta_minutes*/,
-    13 /*letterIndex ("D")*/,
-  },
-  // Rule    Toronto    1947    1949    -    Apr    lastSun    0:00    1:00    D
-  {
-    1947 /*from_year*/,
-    1949 /*to_year*/,
-    4 /*in_month*/,
-    7 /*on_day_of_week*/,
-    0 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    0 /*at_time_code (0/15)*/,
-    60 /*delta_minutes*/,
-    13 /*letterIndex ("D")*/,
-  },
-  // Rule    Toronto    1947    1948    -    Sep    lastSun    0:00    0    S
-  {
-    1947 /*from_year*/,
     1948 /*to_year*/,
     9 /*in_month*/,
     7 /*on_day_of_week*/,
     0 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    0 /*at_time_code (0/15)*/,
+    480 /*at_time_code (7200/15)*/,
     0 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule    Toronto    1949    only    -    Nov    lastSun    0:00    0    S
+  // Rule    Toronto    1946    1973    -    Apr    lastSun    2:00    1:00    D
   {
-    1949 /*from_year*/,
-    1949 /*to_year*/,
-    11 /*in_month*/,
-    7 /*on_day_of_week*/,
-    0 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    0 /*at_time_code (0/15)*/,
-    0 /*delta_minutes*/,
-    25 /*letterIndex ("S")*/,
-  },
-  // Rule    Toronto    1950    1973    -    Apr    lastSun    2:00    1:00    D
-  {
-    1950 /*from_year*/,
+    1946 /*from_year*/,
     1973 /*to_year*/,
     4 /*in_month*/,
     7 /*on_day_of_week*/,
@@ -25084,9 +25036,9 @@ static const AtcZoneRule kAtcZoneRulesToronto[]  = {
     60 /*delta_minutes*/,
     13 /*letterIndex ("D")*/,
   },
-  // Rule    Toronto    1950    only    -    Nov    lastSun    2:00    0    S
+  // Rule    Toronto    1949    1950    -    Nov    lastSun    2:00    0    S
   {
-    1950 /*from_year*/,
+    1949 /*from_year*/,
     1950 /*to_year*/,
     11 /*in_month*/,
     7 /*on_day_of_week*/,
@@ -25125,7 +25077,7 @@ static const AtcZoneRule kAtcZoneRulesToronto[]  = {
 
 const AtcZonePolicy kAtcAllZonePolicyToronto  = {
   kAtcZoneRulesToronto /*rules*/,
-  23 /*num_rules*/,
+  19 /*num_rules*/,
 };
 
 //---------------------------------------------------------------------------

--- a/src/zonedball/zone_policies.h
+++ b/src/zonedball/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,15 +41,15 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1961
+//   Eras: 1963
 //   Policies: 134
-//   Rules: 2238
+//   Rules: 2234
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 402
-//   Eras: 29415
+//   Eras: 29445
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75897
+//   TOTAL: 75879
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 1072
-//   Eras: 39220
+//   Eras: 39260
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94184
+//   TOTAL: 94176
 //
 // DO NOT EDIT
 

--- a/src/zonedball/zone_registry.c
+++ b/src/zonedball/zone_registry.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,15 +41,15 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1961
+//   Eras: 1963
 //   Policies: 134
-//   Rules: 2238
+//   Rules: 2234
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 402
-//   Eras: 29415
+//   Eras: 29445
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75897
+//   TOTAL: 75879
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 1072
-//   Eras: 39220
+//   Eras: 39260
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94184
+//   TOTAL: 94176
 //
 // DO NOT EDIT
 

--- a/src/zonedball/zone_registry.h
+++ b/src/zonedball/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,7 +24,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 596 (351 zones, 245 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -41,15 +41,15 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1961
+//   Eras: 1963
 //   Policies: 134
-//   Rules: 2238
+//   Rules: 2234
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 402
-//   Eras: 29415
+//   Eras: 29445
 //   Zones: 4563
 //   Links: 3185
 //   Registry: 1192
@@ -57,13 +57,13 @@
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75897
+//   TOTAL: 75879
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26856
+//   Rules: 26808
 //   Policies: 1072
-//   Eras: 39220
+//   Eras: 39260
 //   Zones: 8424
 //   Links: 5880
 //   Registry: 2384
@@ -71,7 +71,7 @@
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94184
+//   TOTAL: 94176
 //
 // DO NOT EDIT
 

--- a/src/zonedbtesting/Makefile
+++ b/src/zonedbtesting/Makefile
@@ -8,7 +8,7 @@ zone_registry.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2023d
+TZ_VERSION := 2024a
 START_YEAR := 2000 # unit tests assume start year 2000
 UNTIL_YEAR := 2200
 

--- a/src/zonedbtesting/zone_infos.c
+++ b/src/zonedbtesting/zone_infos.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,7 +25,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (335 zones, 244 links)
@@ -83,7 +83,7 @@
 // ZoneContext
 //---------------------------------------------------------------------------
 
-static const char kAtcTzDatabaseVersion[] = "2023d";
+static const char kAtcTzDatabaseVersion[] = "2024a";
 
 static const char * const kAtcFragments[] = {
 /*\x00*/ NULL,

--- a/src/zonedbtesting/zone_infos.h
+++ b/src/zonedbtesting/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,7 +25,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (335 zones, 244 links)

--- a/src/zonedbtesting/zone_policies.c
+++ b/src/zonedbtesting/zone_policies.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,7 +25,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (335 zones, 244 links)

--- a/src/zonedbtesting/zone_policies.h
+++ b/src/zonedbtesting/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,7 +25,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (335 zones, 244 links)

--- a/src/zonedbtesting/zone_registry.c
+++ b/src/zonedbtesting/zone_registry.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,7 +25,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (335 zones, 244 links)

--- a/src/zonedbtesting/zone_registry.h
+++ b/src/zonedbtesting/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2023d
+//     --tz_version 2024a
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,7 +25,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023d
+// from https://github.com/eggert/tz/releases/tag/2024a
 //
 // Supported Zones: 17 (16 zones, 1 links)
 // Unsupported Zones: 579 (335 zones, 244 links)


### PR DESCRIPTION
- 0.11.2 (2024-07-24, TZDB 2024a)
    - Upgrade TZDB to 2024a
        - https://mm.icann.org/pipermail/tz-announce/2024-February/000081.html
        - "Kazakhstan unifies on UTC+5 beginning 2024-03-01. Palestine springs
          forward a week later after Ramadan. zic no longer pretends to support
          indefinite-past DST. localtime no longer mishandles Ciudad Ju<C3><A1>rez in
          2422."
