### PR TITLE
merge 0.12.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+- 0.12.0 (2024-12-14, TZDB 2024b)
     - Support new `%z` value in FORMAT column.
     - Upgrade TZDB to 2024b
         - https://lists.iana.org/hyperkitty/list/tz-announce@iana.org/thread/IZ7AO6WRE3W3TWBL5IR6PMQUL433BQIE/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 - Unreleased
+    - Support new `%z` value in FORMAT column.
+    - Upgrade TZDB to 2024b
+        - https://lists.iana.org/hyperkitty/list/tz-announce@iana.org/thread/IZ7AO6WRE3W3TWBL5IR6PMQUL433BQIE/
+        - "Improve historical data for Mexico, Mongolia, and Portugal. System V
+          names are now obsolescent. The main data form now uses %z. The code
+          now conforms to RFC 8536 for early timestamps. Support POSIX.1-2024,
+          which removes asctime_r and ctime_r. Assume POSIX.2-1992 or later for
+          shell scripts. SUPPORT_C89 now defaults to 1."
 - 0.11.2 (2024-07-24, TZDB 2024a)
     - Upgrade TZDB to 2024a
         - https://mm.icann.org/pipermail/tz-announce/2024-February/000081.html

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ latter documents.
 
 **Status**: Alpha-level software, not ready for public consumption.
 
-**Version**: 0.11.2 (2024-07-25, TZDB 2024a)
+**Version**: 0.12.0 (2024-12-14, TZDB 2024b)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=acetimec
-version=0.11.2
+version=0.12.0
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=Date, time, timezone library using the C language

--- a/src/acetimec.h
+++ b/src/acetimec.h
@@ -7,8 +7,8 @@
 #define ACE_TIME_C_H
 
 /* Version format: xxyyzz == "xx.yy.zz" */
-#define ACE_TIME_C_VERSION 1102
-#define ACE_TIME_C_VERSION_STRING "0.11.2"
+#define ACE_TIME_C_VERSION 1200
+#define ACE_TIME_C_VERSION_STRING "0.12.0"
 
 #include "zoneinfo/zone_info.h"
 #include "zoneinfo/zone_info_utils.h"

--- a/src/acetimec/common.c
+++ b/src/acetimec/common.c
@@ -38,3 +38,12 @@ uint32_t atc_djb2(const char *s) {
 
   return hash;
 }
+
+void atc_seconds_to_hms(
+    uint32_t seconds, uint16_t *hh, uint16_t *mm, uint16_t *ss)
+{
+  *ss = seconds % 60;
+  uint16_t minutes = seconds / 60;
+  *mm = minutes % 60;
+  *hh = minutes / 60;
+}

--- a/src/acetimec/common.h
+++ b/src/acetimec/common.h
@@ -103,6 +103,10 @@ void atc_copy_replace_string(char *dst, size_t dst_size, const char *src,
  */
 uint32_t atc_djb2(const char *s);
 
+/** Convert (unsigned) seconds to hour, minute, and second components. */
+void atc_seconds_to_hms(
+    uint32_t seconds, uint16_t *hh, uint16_t *mm, uint16_t *ss);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/acetimec/transition.h
+++ b/src/acetimec/transition.h
@@ -26,10 +26,13 @@ extern "C" {
 
 enum {
   /**
-   * Number of characters in a time zone abbreviation. 6 is the maximum
-   * plus 1 for the NUL terminator.
+   * Number of characters in a time zone abbreviation. Most human-assigned
+   * abbreviations have at most 6 characters. But if the FORMAT column is a
+   * "%z", the abbreviation can be generated programmatically using the format
+   * "[+/-]hh[mm[ss]]" which can be 7 characters long. So we need the buffer
+   * size to be 8 to include the terminating NUL character.
    */
-  kAtcAbbrevSize = 7,
+  kAtcAbbrevSize = 8,
 
   /** Number of transitions in the transition_storage. */
   kAtcTransitionStorageSize = 8,
@@ -133,7 +136,7 @@ typedef struct AtcTransition {
   /** The DST delta seconds. */
   int32_t delta_seconds;
 
-  /** The calculated effective time zone abbreviation, e.g. "PST" or "PDT". */
+  /** The computed time zone abbreviation, e.g. "PST", "PDT", or "+0830". */
   char abbrev[kAtcAbbrevSize];
 
   /** Storage for the single letter 'letter' field if 'rule' is not null. */

--- a/src/acetimec/zone_processor.h
+++ b/src/acetimec/zone_processor.h
@@ -391,6 +391,7 @@ void atc_processor_create_abbreviation(
     char *dest,
     uint8_t dest_size,
     const char *format,
+    int32_t offset_seconds,
     int32_t delta_seconds,
     const char *letter_string);
 

--- a/src/zonedb/Makefile
+++ b/src/zonedb/Makefile
@@ -8,7 +8,7 @@ zone_registry.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2024a
+TZ_VERSION := 2024b
 START_YEAR := 2000
 UNTIL_YEAR := 2200
 

--- a/src/zonedb/zone_infos.c
+++ b/src/zonedb/zone_infos.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 657
-//   Policies: 83
-//   Rules: 735
+//   Eras: 644
+//   Policies: 82
+//   Rules: 731
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 8820
-//   Policies: 249
-//   Eras: 9855
-//   Zones: 4563
-//   Links: 3185
+//   Rules: 8772
+//   Policies: 246
+//   Eras: 9660
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 597
+//   Formats: 231
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37599
+//   TOTAL: 36987
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 8820
-//   Policies: 664
-//   Eras: 13140
-//   Zones: 8424
-//   Links: 5880
+//   Rules: 8772
+//   Policies: 656
+//   Eras: 12880
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 597
+//   Formats: 231
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49073
+//   TOTAL: 48391
 //
 // DO NOT EDIT
 
@@ -82,7 +82,7 @@
 // ZoneContext
 //---------------------------------------------------------------------------
 
-static const char kAtcTzDatabaseVersion[] = "2024a";
+static const char kAtcTzDatabaseVersion[] = "2024b";
 
 static const char * const kAtcFragments[] = {
 /*\x00*/ NULL,
@@ -116,8 +116,8 @@ const AtcZoneContext kAtcZoneContext = {
 };
 
 //---------------------------------------------------------------------------
-// Zones: 351
-// Eras: 657
+// Zones: 339
+// Eras: 644
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -258,10 +258,10 @@ const AtcZoneInfo kAtcZoneAfrica_Cairo  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAfrica_Casablanca[]  = {
-  //              0:00    Morocco    +00/+01    2018 Oct 28  3:00
+  //              0:00    Morocco    %z    2018 Oct 28  3:00
   {
     &kAtcZonePolicyMorocco /*zone_policy*/,
-    "+00/+01" /*format*/,
+    "" /*format*/,
     0 /*offset_code (0/15)*/,
     0 /*offset_remainder (0%15)*/,
     0 /*delta_minutes*/,
@@ -271,10 +271,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Casablanca[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              1:00    Morocco    +01/+00
+  //              1:00    Morocco    %z
   {
     &kAtcZonePolicyMorocco /*zone_policy*/,
-    "+01/+00" /*format*/,
+    "" /*format*/,
     240 /*offset_code (3600/15)*/,
     0 /*offset_remainder (3600%15)*/,
     0 /*delta_minutes*/,
@@ -337,10 +337,10 @@ const AtcZoneInfo kAtcZoneAfrica_Ceuta  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAfrica_El_Aaiun[]  = {
-  //              0:00    Morocco    +00/+01    2018 Oct 28  3:00
+  //              0:00    Morocco    %z    2018 Oct 28  3:00
   {
     &kAtcZonePolicyMorocco /*zone_policy*/,
-    "+00/+01" /*format*/,
+    "" /*format*/,
     0 /*offset_code (0/15)*/,
     0 /*offset_remainder (0%15)*/,
     0 /*delta_minutes*/,
@@ -350,10 +350,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_El_Aaiun[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              1:00    Morocco    +01/+00
+  //              1:00    Morocco    %z
   {
     &kAtcZonePolicyMorocco /*zone_policy*/,
-    "+01/+00" /*format*/,
+    "" /*format*/,
     240 /*offset_code (3600/15)*/,
     0 /*offset_remainder (3600%15)*/,
     0 /*delta_minutes*/,
@@ -949,10 +949,10 @@ const AtcZoneInfo kAtcZoneAmerica_Anchorage  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Araguaina[]  = {
-  //             -3:00    Brazil    -03/-02    2003 Sep 24
+  //             -3:00    Brazil    %z    2003 Sep 24
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -962,10 +962,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Araguaina[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2012 Oct 21
+  //             -3:00    -    %z    2012 Oct 21
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -975,10 +975,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Araguaina[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2013 Sep
+  //             -3:00    Brazil    %z    2013 Sep
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -988,10 +988,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Araguaina[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1021,10 +1021,10 @@ const AtcZoneInfo kAtcZoneAmerica_Araguaina  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Buenos_Aires[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1034,10 +1034,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Buenos_Aires[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1047,10 +1047,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Buenos_Aires[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02
+  //             -3:00    Arg    %z
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1080,10 +1080,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_Buenos_Aires  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1093,10 +1093,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1106,10 +1106,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 Jun  1
+  //             -3:00    -    %z    2004 Jun  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1119,10 +1119,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jun 20
+  //             -4:00    -    %z    2004 Jun 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1132,10 +1132,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1145,10 +1145,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1178,10 +1178,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_Catamarca  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Cordoba[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1191,10 +1191,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Cordoba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1204,10 +1204,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Cordoba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02
+  //             -3:00    Arg    %z
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1237,10 +1237,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_Cordoba  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1250,10 +1250,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1263,10 +1263,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1276,10 +1276,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1309,10 +1309,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_Jujuy  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1322,10 +1322,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1335,10 +1335,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 Jun  1
+  //             -3:00    -    %z    2004 Jun  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1348,10 +1348,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jun 20
+  //             -4:00    -    %z    2004 Jun 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1361,10 +1361,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1374,10 +1374,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1407,10 +1407,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_La_Rioja  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1420,10 +1420,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1433,10 +1433,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 May 23
+  //             -3:00    -    %z    2004 May 23
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1446,10 +1446,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Sep 26
+  //             -4:00    -    %z    2004 Sep 26
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1459,10 +1459,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1472,10 +1472,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1505,10 +1505,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_Mendoza  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1518,10 +1518,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1531,10 +1531,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 Jun  1
+  //             -3:00    -    %z    2004 Jun  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1544,10 +1544,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jun 20
+  //             -4:00    -    %z    2004 Jun 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1557,10 +1557,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1570,10 +1570,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1603,10 +1603,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_Rio_Gallegos  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1616,10 +1616,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1629,10 +1629,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1642,10 +1642,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1675,10 +1675,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_Salta  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1688,10 +1688,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1701,10 +1701,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 May 31
+  //             -3:00    -    %z    2004 May 31
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1714,10 +1714,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jul 25
+  //             -4:00    -    %z    2004 Jul 25
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1727,10 +1727,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1740,10 +1740,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1773,10 +1773,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_San_Juan  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
-  //             -3:00    -    -03    1999 Oct  3
+  //             -3:00    -    %z    1999 Oct  3
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1786,10 +1786,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    1:00    -03    2000 Mar  3
+  //             -4:00    1:00    %z    2000 Mar  3
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     60 /*delta_minutes*/,
@@ -1799,10 +1799,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 May 31
+  //             -3:00    -    %z    2004 May 31
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1812,10 +1812,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jul 25
+  //             -4:00    -    %z    2004 Jul 25
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1825,10 +1825,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Jan 21
+  //             -3:00    Arg    %z    2008 Jan 21
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1838,10 +1838,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    SanLuis    -04/-03    2009 Oct 11
+  //             -4:00    SanLuis    %z    2009 Oct 11
   {
     &kAtcZonePolicySanLuis /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1851,10 +1851,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1884,10 +1884,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_San_Luis  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1897,10 +1897,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1910,10 +1910,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 Jun  1
+  //             -3:00    -    %z    2004 Jun  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1923,10 +1923,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jun 13
+  //             -4:00    -    %z    2004 Jun 13
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1936,10 +1936,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02
+  //             -3:00    Arg    %z
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1969,10 +1969,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_Tucuman  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1982,10 +1982,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -1995,10 +1995,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 May 30
+  //             -3:00    -    %z    2004 May 30
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2008,10 +2008,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jun 20
+  //             -4:00    -    %z    2004 Jun 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2021,10 +2021,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2034,10 +2034,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2067,10 +2067,10 @@ const AtcZoneInfo kAtcZoneAmerica_Argentina_Ushuaia  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Asuncion[]  = {
-  //             -4:00    Para    -04/-03
+  //             -4:00    Para    %z
   {
     &kAtcZonePolicyPara /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2100,10 +2100,10 @@ const AtcZoneInfo kAtcZoneAmerica_Asuncion  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Bahia[]  = {
-  //             -3:00    Brazil    -03/-02    2003 Sep 24
+  //             -3:00    Brazil    %z    2003 Sep 24
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2113,10 +2113,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bahia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2011 Oct 16
+  //             -3:00    -    %z    2011 Oct 16
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2126,10 +2126,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bahia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2012 Oct 21
+  //             -3:00    Brazil    %z    2012 Oct 21
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2139,10 +2139,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bahia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2251,10 +2251,10 @@ const AtcZoneInfo kAtcZoneAmerica_Barbados  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Belem[]  = {
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2317,10 +2317,10 @@ const AtcZoneInfo kAtcZoneAmerica_Belize  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Boa_Vista[]  = {
-  //             -4:00    -    -04    1999 Sep 30
+  //             -4:00    -    %z    1999 Sep 30
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2330,10 +2330,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Boa_Vista[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03    2000 Oct 15
+  //             -4:00    Brazil    %z    2000 Oct 15
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2343,10 +2343,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Boa_Vista[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2376,10 +2376,10 @@ const AtcZoneInfo kAtcZoneAmerica_Boa_Vista  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Bogota[]  = {
-  //             -5:00    CO    -05/-04
+  //             -5:00    CO    %z
   {
     &kAtcZonePolicyCO /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -2527,10 +2527,10 @@ const AtcZoneInfo kAtcZoneAmerica_Cambridge_Bay  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Campo_Grande[]  = {
-  //             -4:00    Brazil    -04/-03
+  //             -4:00    Brazil    %z
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2606,10 +2606,10 @@ const AtcZoneInfo kAtcZoneAmerica_Cancun  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Caracas[]  = {
-  //             -4:00    -    -04    2007 Dec  9  3:00
+  //             -4:00    -    %z    2007 Dec  9  3:00
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2619,10 +2619,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Caracas[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:30    -    -0430    2016 May  1  2:30
+  //             -4:30    -    %z    2016 May  1  2:30
   {
     NULL /*zone_policy*/,
-    "-0430" /*format*/,
+    "" /*format*/,
     -1080 /*offset_code (-16200/15)*/,
     0 /*offset_remainder (-16200%15)*/,
     0 /*delta_minutes*/,
@@ -2632,10 +2632,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Caracas[]  = {
     600 /*until_time_code (9000/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2665,10 +2665,10 @@ const AtcZoneInfo kAtcZoneAmerica_Caracas  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Cayenne[]  = {
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2882,10 +2882,10 @@ const AtcZoneInfo kAtcZoneAmerica_Costa_Rica  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Cuiaba[]  = {
-  //             -4:00    Brazil    -04/-03    2003 Sep 24
+  //             -4:00    Brazil    %z    2003 Sep 24
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2895,10 +2895,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Cuiaba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Oct  1
+  //             -4:00    -    %z    2004 Oct  1
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2908,10 +2908,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Cuiaba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03
+  //             -4:00    Brazil    %z
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3152,10 +3152,10 @@ const AtcZoneInfo kAtcZoneAmerica_Edmonton  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Eirunepe[]  = {
-  //             -5:00    -    -05    2008 Jun 24  0:00
+  //             -5:00    -    %z    2008 Jun 24  0:00
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -3165,10 +3165,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Eirunepe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2013 Nov 10
+  //             -4:00    -    %z    2013 Nov 10
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3178,10 +3178,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Eirunepe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05
+  //             -5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -3290,10 +3290,10 @@ const AtcZoneInfo kAtcZoneAmerica_Fort_Nelson  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
-  //             -3:00    -    -03    1999 Sep 30
+  //             -3:00    -    %z    1999 Sep 30
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3303,10 +3303,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2000 Oct 22
+  //             -3:00    Brazil    %z    2000 Oct 22
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3316,10 +3316,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2001 Sep 13
+  //             -3:00    -    %z    2001 Sep 13
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3329,10 +3329,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2002 Oct  1
+  //             -3:00    Brazil    %z    2002 Oct  1
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3342,10 +3342,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3546,10 +3546,10 @@ const AtcZoneInfo kAtcZoneAmerica_Guatemala  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Guayaquil[]  = {
-  //             -5:00    Ecuador    -05/-04
+  //             -5:00    Ecuador    %z
   {
     &kAtcZonePolicyEcuador /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -3579,10 +3579,10 @@ const AtcZoneInfo kAtcZoneAmerica_Guayaquil  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Guyana[]  = {
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4368,10 +4368,10 @@ const AtcZoneInfo kAtcZoneAmerica_Kentucky_Monticello  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_La_Paz[]  = {
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4401,10 +4401,10 @@ const AtcZoneInfo kAtcZoneAmerica_La_Paz  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Lima[]  = {
-  //             -5:00    Peru    -05/-04
+  //             -5:00    Peru    %z
   {
     &kAtcZonePolicyPeru /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -4467,10 +4467,10 @@ const AtcZoneInfo kAtcZoneAmerica_Los_Angeles  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
-  //             -3:00    -    -03    1999 Sep 30
+  //             -3:00    -    %z    1999 Sep 30
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4480,10 +4480,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2000 Oct 22
+  //             -3:00    Brazil    %z    2000 Oct 22
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4493,10 +4493,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2001 Sep 13
+  //             -3:00    -    %z    2001 Sep 13
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4506,10 +4506,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2002 Oct  1
+  //             -3:00    Brazil    %z    2002 Oct  1
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4519,10 +4519,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4585,10 +4585,10 @@ const AtcZoneInfo kAtcZoneAmerica_Managua  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Manaus[]  = {
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4927,10 +4927,10 @@ const AtcZoneInfo kAtcZoneAmerica_Mexico_City  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Miquelon[]  = {
-  //             -3:00    Canada    -03/-02
+  //             -3:00    Canada    %z
   {
     &kAtcZonePolicyCanada /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5039,10 +5039,10 @@ const AtcZoneInfo kAtcZoneAmerica_Monterrey  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Montevideo[]  = {
-  //             -3:00    Uruguay    -03/-02
+  //             -3:00    Uruguay    %z
   {
     &kAtcZonePolicyUruguay /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5138,10 +5138,10 @@ const AtcZoneInfo kAtcZoneAmerica_Nome  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
-  //             -2:00    -    -02    1999 Sep 30
+  //             -2:00    -    %z    1999 Sep 30
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -5151,10 +5151,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    Brazil    -02/-01    2000 Oct 15
+  //             -2:00    Brazil    %z    2000 Oct 15
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -5164,10 +5164,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    -    -02    2001 Sep 13
+  //             -2:00    -    %z    2001 Sep 13
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -5177,10 +5177,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    Brazil    -02/-01    2002 Oct  1
+  //             -2:00    Brazil    %z    2002 Oct  1
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -5190,10 +5190,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    -    -02
+  //             -2:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -5348,10 +5348,10 @@ const AtcZoneInfo kAtcZoneAmerica_North_Dakota_New_Salem  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Nuuk[]  = {
-  //             -3:00    EU    -03/-02    2023 Mar 26  1:00u
+  //             -3:00    EU    %z    2023 Mar 26  1:00u
   {
     &kAtcZonePolicyEU /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5361,10 +5361,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Nuuk[]  = {
     240 /*until_time_code (3600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -2:00    -    -02    2023 Oct 29  1:00u
+  //             -2:00    -    %z    2023 Oct 29  1:00u
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -5374,10 +5374,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Nuuk[]  = {
     240 /*until_time_code (3600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -2:00    EU    -02/-01
+  //             -2:00    EU    %z
   {
     &kAtcZonePolicyEU /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -5512,10 +5512,10 @@ const AtcZoneInfo kAtcZoneAmerica_Panama  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Paramaribo[]  = {
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5611,10 +5611,10 @@ const AtcZoneInfo kAtcZoneAmerica_Port_au_Prince  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Porto_Velho[]  = {
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -5677,10 +5677,10 @@ const AtcZoneInfo kAtcZoneAmerica_Puerto_Rico  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
-  //             -4:00    Chile    -04/-03    2016 Dec  4
+  //             -4:00    Chile    %z    2016 Dec  4
   {
     &kAtcZonePolicyChile /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -5690,10 +5690,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5782,10 +5782,10 @@ const AtcZoneInfo kAtcZoneAmerica_Rankin_Inlet  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
-  //             -3:00    -    -03    1999 Sep 30
+  //             -3:00    -    %z    1999 Sep 30
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5795,10 +5795,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2000 Oct 15
+  //             -3:00    Brazil    %z    2000 Oct 15
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5808,10 +5808,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2001 Sep 13
+  //             -3:00    -    %z    2001 Sep 13
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5821,10 +5821,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2002 Oct  1
+  //             -3:00    Brazil    %z    2002 Oct  1
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5834,10 +5834,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5985,10 +5985,10 @@ const AtcZoneInfo kAtcZoneAmerica_Resolute  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Rio_Branco[]  = {
-  //             -5:00    -    -05    2008 Jun 24  0:00
+  //             -5:00    -    %z    2008 Jun 24  0:00
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -5998,10 +5998,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Rio_Branco[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2013 Nov 10
+  //             -4:00    -    %z    2013 Nov 10
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -6011,10 +6011,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Rio_Branco[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05
+  //             -5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -6044,10 +6044,10 @@ const AtcZoneInfo kAtcZoneAmerica_Rio_Branco  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Santarem[]  = {
-  //             -4:00    -    -04    2008 Jun 24  0:00
+  //             -4:00    -    %z    2008 Jun 24  0:00
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -6057,10 +6057,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santarem[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -6090,10 +6090,10 @@ const AtcZoneInfo kAtcZoneAmerica_Santarem  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
-  //             -4:00    Chile    -04/-03
+  //             -4:00    Chile    %z
   {
     &kAtcZonePolicyChile /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -6182,10 +6182,10 @@ const AtcZoneInfo kAtcZoneAmerica_Santo_Domingo  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Sao_Paulo[]  = {
-  //             -3:00    Brazil    -03/-02
+  //             -3:00    Brazil    %z
   {
     &kAtcZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -6215,10 +6215,10 @@ const AtcZoneInfo kAtcZoneAmerica_Sao_Paulo  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Scoresbysund[]  = {
-  //             -1:00    EU    -01/+00 2024 Mar 31
+  //             -1:00    EU    %z    2024 Mar 31
   {
     &kAtcZonePolicyEU /*zone_policy*/,
-    "-01/+00" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -6228,10 +6228,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Scoresbysund[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    EU    -02/-01
+  //             -2:00    EU    %z
   {
     &kAtcZonePolicyEU /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -6702,10 +6702,10 @@ const AtcZoneInfo kAtcZoneAmerica_Yakutat  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
-  //              8:00    -    +08    2009 Oct 18  2:00
+  //              8:00    -    %z    2009 Oct 18  2:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -6715,10 +6715,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2010 Mar  5  2:00
+  //             11:00    -    %z    2010 Mar  5  2:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -6728,10 +6728,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2011 Oct 28  2:00
+  //              8:00    -    %z    2011 Oct 28  2:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -6741,10 +6741,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2012 Feb 21 17:00u
+  //             11:00    -    %z    2012 Feb 21 17:00u
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -6754,10 +6754,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     4080 /*until_time_code (61200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //              8:00    -    +08    2016 Oct 22
+  //              8:00    -    %z    2016 Oct 22
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -6767,10 +6767,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2018 Mar 11  4:00
+  //             11:00    -    %z    2018 Mar 11  4:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -6780,10 +6780,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     960 /*until_time_code (14400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2018 Oct  7  4:00
+  //              8:00    -    %z    2018 Oct  7  4:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -6793,10 +6793,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     960 /*until_time_code (14400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2019 Mar 17  3:00
+  //             11:00    -    %z    2019 Mar 17  3:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -6806,10 +6806,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2019 Oct  4  3:00
+  //              8:00    -    %z    2019 Oct  4  3:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -6819,10 +6819,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2020 Mar  8  3:00
+  //             11:00    -    %z    2020 Mar  8  3:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -6832,10 +6832,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2020 Oct  4  0:01
+  //              8:00    -    %z    2020 Oct  4  0:01
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -6845,10 +6845,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     4 /*until_time_code (60/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2021 Mar 14  0:00
+  //             11:00    -    %z    2021 Mar 14  0:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -6858,10 +6858,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2021 Oct  3  0:01
+  //              8:00    -    %z    2021 Oct  3  0:01
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -6871,10 +6871,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     4 /*until_time_code (60/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2022 Mar 13  0:00
+  //             11:00    -    %z    2022 Mar 13  0:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -6884,10 +6884,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2022 Oct  2  0:01
+  //              8:00    -    %z    2022 Oct  2  0:01
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -6897,10 +6897,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     4 /*until_time_code (60/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2023 Mar  9  3:00
+  //             11:00    -    %z    2023 Mar  9  3:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -6910,10 +6910,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08
+  //              8:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -6943,10 +6943,10 @@ const AtcZoneInfo kAtcZoneAntarctica_Casey  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
-  //             7:00    -    +07    2009 Oct 18  2:00
+  //             7:00    -    %z    2009 Oct 18  2:00
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -6956,10 +6956,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    2010 Mar 10 20:00u
+  //             5:00    -    %z    2010 Mar 10 20:00u
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -6969,10 +6969,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
     4800 /*until_time_code (72000/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             7:00    -    +07    2011 Oct 28  2:00
+  //             7:00    -    %z    2011 Oct 28  2:00
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -6982,10 +6982,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    2012 Feb 21 20:00u
+  //             5:00    -    %z    2012 Feb 21 20:00u
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -6995,10 +6995,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
     4800 /*until_time_code (72000/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             7:00    -    +07
+  //             7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -7087,10 +7087,10 @@ const AtcZoneInfo kAtcZoneAntarctica_Macquarie  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAntarctica_Mawson[]  = {
-  //             6:00    -    +06    2009 Oct 18  2:00
+  //             6:00    -    %z    2009 Oct 18  2:00
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -7100,10 +7100,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Mawson[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -7133,10 +7133,10 @@ const AtcZoneInfo kAtcZoneAntarctica_Mawson  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAntarctica_Palmer[]  = {
-  //             -4:00    Chile    -04/-03    2016 Dec  4
+  //             -4:00    Chile    %z    2016 Dec  4
   {
     &kAtcZonePolicyChile /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -7146,10 +7146,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Palmer[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -7179,10 +7179,10 @@ const AtcZoneInfo kAtcZoneAntarctica_Palmer  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAntarctica_Rothera[]  = {
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -7258,10 +7258,10 @@ const AtcZoneInfo kAtcZoneAntarctica_Troll  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAntarctica_Vostok[]  = {
-  //             7:00    -    +07    2023 Dec 18  2:00
+  //             7:00    -    %z    2023 Dec 18  2:00
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -7271,10 +7271,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Vostok[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -7304,10 +7304,10 @@ const AtcZoneInfo kAtcZoneAntarctica_Vostok  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
-  //             6:00 RussiaAsia    +06/+07    2004 Oct 31  2:00s
+  //             6:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcZonePolicyRussiaAsia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -7317,10 +7317,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00    -    +06    2024 Mar  1  0:00
+  //             6:00    -    %z    2024 Mar  1  0:00
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -7330,10 +7330,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -7376,10 +7376,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Amman[]  = {
     0 /*until_time_code (0/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -7409,10 +7409,10 @@ const AtcZoneInfo kAtcZoneAsia_Amman  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Anadyr[]  = {
-  //             12:00    Russia    +12/+13    2010 Mar 28  2:00s
+  //             12:00    Russia    %z    2010 Mar 28  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+12/+13" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -7422,10 +7422,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Anadyr[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    2011 Mar 27  2:00s
+  //             11:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -7435,10 +7435,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Anadyr[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    -    +12
+  //             12:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -7468,10 +7468,10 @@ const AtcZoneInfo kAtcZoneAsia_Anadyr  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Aqtau[]  = {
-  //             4:00 RussiaAsia    +04/+05    2004 Oct 31  2:00s
+  //             4:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -7481,10 +7481,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -7514,10 +7514,10 @@ const AtcZoneInfo kAtcZoneAsia_Aqtau  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Aqtobe[]  = {
-  //             5:00 RussiaAsia    +05/+06    2004 Oct 31  2:00s
+  //             5:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -7527,10 +7527,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtobe[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -7560,10 +7560,10 @@ const AtcZoneInfo kAtcZoneAsia_Aqtobe  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Ashgabat[]  = {
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -7593,10 +7593,10 @@ const AtcZoneInfo kAtcZoneAsia_Ashgabat  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
-  //             5:00 RussiaAsia    +05/+06    1999 Mar 28  2:00s
+  //             5:00 RussiaAsia    %z    1999 Mar 28  2:00s
   {
     &kAtcZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -7606,10 +7606,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    2004 Oct 31  2:00s
+  //             4:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -7619,10 +7619,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -7652,10 +7652,10 @@ const AtcZoneInfo kAtcZoneAsia_Atyrau  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Baghdad[]  = {
-  //             3:00    Iraq    +03/+04
+  //             3:00    Iraq    %z
   {
     &kAtcZonePolicyIraq /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -7685,10 +7685,10 @@ const AtcZoneInfo kAtcZoneAsia_Baghdad  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Baku[]  = {
-  //             4:00    Azer    +04/+05
+  //             4:00    Azer    %z
   {
     &kAtcZonePolicyAzer /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -7718,10 +7718,10 @@ const AtcZoneInfo kAtcZoneAsia_Baku  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Bangkok[]  = {
-  //             7:00    -    +07
+  //             7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -7751,10 +7751,10 @@ const AtcZoneInfo kAtcZoneAsia_Bangkok  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
-  //              6:00    Russia    +06/+07    2011 Mar 27  2:00s
+  //              6:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -7764,10 +7764,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07    2014 Oct 26  2:00s
+  //              7:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -7777,10 +7777,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    -    +06    2016 Mar 27  2:00s
+  //              6:00    -    %z    2016 Mar 27  2:00s
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -7790,10 +7790,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07
+  //              7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -7856,10 +7856,10 @@ const AtcZoneInfo kAtcZoneAsia_Beirut  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Bishkek[]  = {
-  //             5:00    Kyrgyz    +05/+06    2005 Aug 12
+  //             5:00    Kyrgyz    %z    2005 Aug 12
   {
     &kAtcZonePolicyKyrgyz /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -7869,10 +7869,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Bishkek[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06
+  //             6:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -7902,10 +7902,10 @@ const AtcZoneInfo kAtcZoneAsia_Bishkek  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
-  //              9:00    Russia    +09/+10    2011 Mar 27  2:00s
+  //              9:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -7915,10 +7915,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10    2014 Oct 26  2:00s
+  //             10:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -7928,10 +7928,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              8:00    -    +08    2016 Mar 27  2:00
+  //              8:00    -    %z    2016 Mar 27  2:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -7941,10 +7941,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    -    +09
+  //              9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -7969,61 +7969,15 @@ const AtcZoneInfo kAtcZoneAsia_Chita  = {
 };
 
 //---------------------------------------------------------------------------
-// Zone name: Asia/Choibalsan
-// Zone Eras: 2
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraAsia_Choibalsan[]  = {
-  //             9:00    Mongol    +09/+10    2008 Mar 31
-  {
-    &kAtcZonePolicyMongol /*zone_policy*/,
-    "+09/+10" /*format*/,
-    2160 /*offset_code (32400/15)*/,
-    0 /*offset_remainder (32400%15)*/,
-    0 /*delta_minutes*/,
-    2008 /*until_year*/,
-    3 /*until_month*/,
-    31 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-  //             8:00    Mongol    +08/+09
-  {
-    &kAtcZonePolicyMongol /*zone_policy*/,
-    "+08/+09" /*format*/,
-    1920 /*offset_code (28800/15)*/,
-    0 /*offset_remainder (28800%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameAsia_Choibalsan[]  = "Asia/Choibalsan";
-
-const AtcZoneInfo kAtcZoneAsia_Choibalsan  = {
-  kAtcZoneNameAsia_Choibalsan /*name*/,
-  0x928aa4a6 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  2 /*num_eras*/,
-  kAtcZoneEraAsia_Choibalsan /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
 // Zone name: Asia/Colombo
 // Zone Eras: 2
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Colombo[]  = {
-  //             6:00    -    +06    2006 Apr 15  0:30
+  //             6:00    -    %z    2006 Apr 15  0:30
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -8033,10 +7987,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Colombo[]  = {
     120 /*until_time_code (1800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    -    +0530
+  //             5:30    -    %z
   {
     NULL /*zone_policy*/,
-    "+0530" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     0 /*delta_minutes*/,
@@ -8079,10 +8033,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Damascus[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -8112,10 +8066,10 @@ const AtcZoneInfo kAtcZoneAsia_Damascus  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Dhaka[]  = {
-  //             6:00    -    +06    2009
+  //             6:00    -    %z    2009
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -8125,10 +8079,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dhaka[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    Dhaka    +06/+07
+  //             6:00    Dhaka    %z
   {
     &kAtcZonePolicyDhaka /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -8158,10 +8112,10 @@ const AtcZoneInfo kAtcZoneAsia_Dhaka  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Dili[]  = {
-  //             8:00    -    +08    2000 Sep 17  0:00
+  //             8:00    -    %z    2000 Sep 17  0:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -8171,10 +8125,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dili[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09
+  //             9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -8204,10 +8158,10 @@ const AtcZoneInfo kAtcZoneAsia_Dili  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Dubai[]  = {
-  //             4:00    -    +04
+  //             4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -8237,10 +8191,10 @@ const AtcZoneInfo kAtcZoneAsia_Dubai  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Dushanbe[]  = {
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -8283,10 +8237,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Famagusta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03    2017 Oct 29 1:00u
+  //             3:00    -    %z    2017 Oct 29 1:00u
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -8499,10 +8453,10 @@ const AtcZoneInfo kAtcZoneAsia_Hebron  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
-  //             7:00    -    +07
+  //             7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -8565,10 +8519,10 @@ const AtcZoneInfo kAtcZoneAsia_Hong_Kong  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Hovd[]  = {
-  //             7:00    Mongol    +07/+08
+  //             7:00    Mongol    %z
   {
     &kAtcZonePolicyMongol /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -8598,10 +8552,10 @@ const AtcZoneInfo kAtcZoneAsia_Hovd  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Irkutsk[]  = {
-  //              8:00    Russia    +08/+09    2011 Mar 27  2:00s
+  //              8:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+08/+09" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -8611,10 +8565,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Irkutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              9:00    -    +09    2014 Oct 26  2:00s
+  //              9:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -8624,10 +8578,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Irkutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              8:00    -    +08
+  //              8:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -8756,10 +8710,10 @@ const AtcZoneInfo kAtcZoneAsia_Jerusalem  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Kabul[]  = {
-  //             4:30    -    +0430
+  //             4:30    -    %z
   {
     NULL /*zone_policy*/,
-    "+0430" /*format*/,
+    "" /*format*/,
     1080 /*offset_code (16200/15)*/,
     0 /*offset_remainder (16200%15)*/,
     0 /*delta_minutes*/,
@@ -8789,10 +8743,10 @@ const AtcZoneInfo kAtcZoneAsia_Kabul  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Kamchatka[]  = {
-  //             12:00    Russia    +12/+13    2010 Mar 28  2:00s
+  //             12:00    Russia    %z    2010 Mar 28  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+12/+13" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -8802,10 +8756,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kamchatka[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    2011 Mar 27  2:00s
+  //             11:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -8815,10 +8769,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kamchatka[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    -    +12
+  //             12:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -8881,10 +8835,10 @@ const AtcZoneInfo kAtcZoneAsia_Karachi  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Kathmandu[]  = {
-  //             5:45    -    +0545
+  //             5:45    -    %z
   {
     NULL /*zone_policy*/,
-    "+0545" /*format*/,
+    "" /*format*/,
     1380 /*offset_code (20700/15)*/,
     0 /*offset_remainder (20700%15)*/,
     0 /*delta_minutes*/,
@@ -8914,10 +8868,10 @@ const AtcZoneInfo kAtcZoneAsia_Kathmandu  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
-  //              9:00    Russia    +09/+10    2004
+  //              9:00    Russia    %z    2004
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -8927,10 +8881,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             10:00    Russia    +10/+11    2011 Mar 27  2:00s
+  //             10:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -8940,10 +8894,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11    2011 Sep 13  0:00s
+  //             11:00    -    %z    2011 Sep 13  0:00s
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -8953,10 +8907,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     0 /*until_time_code (0/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10    2014 Oct 26  2:00s
+  //             10:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -8966,10 +8920,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              9:00    -    +09
+  //              9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -9032,10 +8986,10 @@ const AtcZoneInfo kAtcZoneAsia_Kolkata  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Krasnoyarsk[]  = {
-  //              7:00    Russia    +07/+08    2011 Mar 27  2:00s
+  //              7:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -9045,10 +8999,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Krasnoyarsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              8:00    -    +08    2014 Oct 26  2:00s
+  //              8:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -9058,10 +9012,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Krasnoyarsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07
+  //              7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -9091,10 +9045,10 @@ const AtcZoneInfo kAtcZoneAsia_Krasnoyarsk  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Kuching[]  = {
-  //             8:00    -    +08
+  //             8:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -9157,10 +9111,10 @@ const AtcZoneInfo kAtcZoneAsia_Macau  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
-  //             11:00    Russia    +11/+12    2011 Mar 27  2:00s
+  //             11:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -9170,10 +9124,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    -    +12    2014 Oct 26  2:00s
+  //             12:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -9183,10 +9137,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10    2016 Apr 24  2:00s
+  //             10:00    -    %z    2016 Apr 24  2:00s
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -9196,10 +9150,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -9328,10 +9282,10 @@ const AtcZoneInfo kAtcZoneAsia_Nicosia  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Novokuznetsk[]  = {
-  //              7:00    Russia    +07/+08    2010 Mar 28  2:00s
+  //              7:00    Russia    %z    2010 Mar 28  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -9341,10 +9295,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novokuznetsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    2011 Mar 27  2:00s
+  //              6:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -9354,10 +9308,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novokuznetsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07
+  //              7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -9387,10 +9341,10 @@ const AtcZoneInfo kAtcZoneAsia_Novokuznetsk  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
-  //              6:00    Russia    +06/+07    2011 Mar 27  2:00s
+  //              6:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -9400,10 +9354,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07    2014 Oct 26  2:00s
+  //              7:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -9413,10 +9367,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    -    +06    2016 Jul 24  2:00s
+  //              6:00    -    %z    2016 Jul 24  2:00s
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -9426,10 +9380,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07
+  //              7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -9459,10 +9413,10 @@ const AtcZoneInfo kAtcZoneAsia_Novosibirsk  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Omsk[]  = {
-  //              6:00    Russia    +06/+07    2011 Mar 27  2:00s
+  //              6:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -9472,10 +9426,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Omsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07    2014 Oct 26  2:00s
+  //              7:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -9485,10 +9439,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Omsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    -    +06
+  //              6:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -9518,10 +9472,10 @@ const AtcZoneInfo kAtcZoneAsia_Omsk  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
-  //             4:00 RussiaAsia    +04/+05    2004 Oct 31  2:00s
+  //             4:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -9531,10 +9485,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -9656,10 +9610,10 @@ const AtcZoneInfo kAtcZoneAsia_Pyongyang  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Qatar[]  = {
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -9689,10 +9643,10 @@ const AtcZoneInfo kAtcZoneAsia_Qatar  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
-  //             5:00 RussiaAsia    +05/+06    2004 Oct 31  2:00s
+  //             5:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -9702,10 +9656,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00    -    +06    2024 Mar  1  0:00
+  //             6:00    -    %z    2024 Mar  1  0:00
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -9715,10 +9669,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -9748,10 +9702,10 @@ const AtcZoneInfo kAtcZoneAsia_Qostanay  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
-  //             5:00 RussiaAsia    +05/+06    2004 Oct 31  2:00s
+  //             5:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -9761,10 +9715,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00    -    +06    2018 Dec 21  0:00
+  //             6:00    -    %z    2018 Dec 21  0:00
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -9774,10 +9728,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -9807,10 +9761,10 @@ const AtcZoneInfo kAtcZoneAsia_Qyzylorda  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Riyadh[]  = {
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -9840,10 +9794,10 @@ const AtcZoneInfo kAtcZoneAsia_Riyadh  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
-  //             10:00    Russia    +10/+11    2011 Mar 27  2:00s
+  //             10:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -9853,10 +9807,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11    2014 Oct 26  2:00s
+  //             11:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -9866,10 +9820,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10    2016 Mar 27  2:00s
+  //             10:00    -    %z    2016 Mar 27  2:00s
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -9879,10 +9833,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -9912,10 +9866,10 @@ const AtcZoneInfo kAtcZoneAsia_Sakhalin  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Samarkand[]  = {
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -10011,10 +9965,10 @@ const AtcZoneInfo kAtcZoneAsia_Shanghai  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Singapore[]  = {
-  //             8:00    -    +08
+  //             8:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -10044,10 +9998,10 @@ const AtcZoneInfo kAtcZoneAsia_Singapore  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Srednekolymsk[]  = {
-  //             11:00    Russia    +11/+12    2011 Mar 27  2:00s
+  //             11:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -10057,10 +10011,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Srednekolymsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    -    +12    2014 Oct 26  2:00s
+  //             12:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -10070,10 +10024,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Srednekolymsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -10136,10 +10090,10 @@ const AtcZoneInfo kAtcZoneAsia_Taipei  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Tashkent[]  = {
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -10169,10 +10123,10 @@ const AtcZoneInfo kAtcZoneAsia_Tashkent  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
-  //             4:00 E-EurAsia    +04/+05    2004 Jun 27
+  //             4:00 E-EurAsia    %z    2004 Jun 27
   {
     &kAtcZonePolicyE_EurAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -10182,10 +10136,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00 RussiaAsia    +03/+04    2005 Mar lastSun  2:00
+  //             3:00 RussiaAsia    %z    2005 Mar lastSun  2:00
   {
     &kAtcZonePolicyRussiaAsia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -10195,10 +10149,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04
+  //             4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -10228,10 +10182,10 @@ const AtcZoneInfo kAtcZoneAsia_Tbilisi  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Tehran[]  = {
-  //             3:30    Iran    +0330/+0430
+  //             3:30    Iran    %z
   {
     &kAtcZonePolicyIran /*zone_policy*/,
-    "+0330/+0430" /*format*/,
+    "" /*format*/,
     840 /*offset_code (12600/15)*/,
     0 /*offset_remainder (12600%15)*/,
     0 /*delta_minutes*/,
@@ -10261,10 +10215,10 @@ const AtcZoneInfo kAtcZoneAsia_Tehran  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Thimphu[]  = {
-  //             6:00    -    +06
+  //             6:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -10327,10 +10281,10 @@ const AtcZoneInfo kAtcZoneAsia_Tokyo  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
-  //              7:00    Russia    +07/+08    2002 May  1  3:00
+  //              7:00    Russia    %z    2002 May  1  3:00
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -10340,10 +10294,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    2011 Mar 27  2:00s
+  //              6:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -10353,10 +10307,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07    2014 Oct 26  2:00s
+  //              7:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -10366,10 +10320,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    -    +06    2016 May 29  2:00s
+  //              6:00    -    %z    2016 May 29  2:00s
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -10379,10 +10333,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07
+  //              7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -10412,10 +10366,10 @@ const AtcZoneInfo kAtcZoneAsia_Tomsk  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Ulaanbaatar[]  = {
-  //             8:00    Mongol    +08/+09
+  //             8:00    Mongol    %z
   {
     &kAtcZonePolicyMongol /*zone_policy*/,
-    "+08/+09" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -10445,10 +10399,10 @@ const AtcZoneInfo kAtcZoneAsia_Ulaanbaatar  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Urumqi[]  = {
-  //             6:00    -    +06
+  //             6:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -10478,10 +10432,10 @@ const AtcZoneInfo kAtcZoneAsia_Urumqi  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
-  //             11:00    Russia    +11/+12    2011 Mar 27  2:00s
+  //             11:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -10491,10 +10445,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    -    +12    2011 Sep 13  0:00s
+  //             12:00    -    %z    2011 Sep 13  0:00s
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -10504,10 +10458,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     0 /*until_time_code (0/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11    2014 Oct 26  2:00s
+  //             11:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -10517,10 +10471,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10
+  //             10:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -10550,10 +10504,10 @@ const AtcZoneInfo kAtcZoneAsia_Ust_Nera  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Vladivostok[]  = {
-  //             10:00    Russia    +10/+11    2011 Mar 27  2:00s
+  //             10:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -10563,10 +10517,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Vladivostok[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11    2014 Oct 26  2:00s
+  //             11:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -10576,10 +10530,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Vladivostok[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10
+  //             10:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -10609,10 +10563,10 @@ const AtcZoneInfo kAtcZoneAsia_Vladivostok  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Yakutsk[]  = {
-  //              9:00    Russia    +09/+10    2011 Mar 27  2:00s
+  //              9:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -10622,10 +10576,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yakutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10    2014 Oct 26  2:00s
+  //             10:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -10635,10 +10589,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yakutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              9:00    -    +09
+  //              9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -10668,10 +10622,10 @@ const AtcZoneInfo kAtcZoneAsia_Yakutsk  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Yangon[]  = {
-  //             6:30    -    +0630
+  //             6:30    -    %z
   {
     NULL /*zone_policy*/,
-    "+0630" /*format*/,
+    "" /*format*/,
     1560 /*offset_code (23400/15)*/,
     0 /*offset_remainder (23400%15)*/,
     0 /*delta_minutes*/,
@@ -10701,10 +10655,10 @@ const AtcZoneInfo kAtcZoneAsia_Yangon  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Yekaterinburg[]  = {
-  //              5:00    Russia    +05/+06    2011 Mar 27  2:00s
+  //              5:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -10714,10 +10668,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yekaterinburg[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    -    +06    2014 Oct 26  2:00s
+  //              6:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -10727,10 +10681,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yekaterinburg[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              5:00    -    +05
+  //              5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -10760,10 +10714,10 @@ const AtcZoneInfo kAtcZoneAsia_Yekaterinburg  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Yerevan[]  = {
-  //             4:00 RussiaAsia    +04/+05    2011
+  //             4:00 RussiaAsia    %z    2011
   {
     &kAtcZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -10773,10 +10727,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yerevan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    Armenia    +04/+05
+  //             4:00    Armenia    %z
   {
     &kAtcZonePolicyArmenia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -10806,10 +10760,10 @@ const AtcZoneInfo kAtcZoneAsia_Yerevan  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAtlantic_Azores[]  = {
-  //             -1:00    EU    -01/+00
+  //             -1:00    EU    %z
   {
     &kAtcZonePolicyEU /*zone_policy*/,
-    "-01/+00" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -10905,10 +10859,10 @@ const AtcZoneInfo kAtcZoneAtlantic_Canary  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAtlantic_Cape_Verde[]  = {
-  //             -1:00    -    -01
+  //             -1:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-01" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -11004,10 +10958,10 @@ const AtcZoneInfo kAtcZoneAtlantic_Madeira  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAtlantic_South_Georgia[]  = {
-  //             -2:00    -    -02
+  //             -2:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -11037,10 +10991,10 @@ const AtcZoneInfo kAtcZoneAtlantic_South_Georgia  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAtlantic_Stanley[]  = {
-  //             -4:00    Falk    -04/-03    2010 Sep  5  2:00
+  //             -4:00    Falk    %z    2010 Sep  5  2:00
   {
     &kAtcZonePolicyFalk /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -11050,10 +11004,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Stanley[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -11228,10 +11182,10 @@ const AtcZoneInfo kAtcZoneAustralia_Darwin  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAustralia_Eucla[]  = {
-  //              8:45    AW  +0845/+0945
+  //              8:45    AW    %z
   {
     &kAtcZonePolicyAW /*zone_policy*/,
-    "+0845/+0945" /*format*/,
+    "" /*format*/,
     2100 /*offset_code (31500/15)*/,
     0 /*offset_remainder (31500%15)*/,
     0 /*delta_minutes*/,
@@ -11327,10 +11281,10 @@ const AtcZoneInfo kAtcZoneAustralia_Lindeman  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAustralia_Lord_Howe[]  = {
-  //             10:30    LH    +1030/+11
+  //             10:30    LH    %z
   {
     &kAtcZonePolicyLH /*zone_policy*/,
-    "+1030/+11" /*format*/,
+    "" /*format*/,
     2520 /*offset_code (37800/15)*/,
     0 /*offset_remainder (37800%15)*/,
     0 /*delta_minutes*/,
@@ -11454,171 +11408,6 @@ const AtcZoneInfo kAtcZoneAustralia_Sydney  = {
 };
 
 //---------------------------------------------------------------------------
-// Zone name: CET
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraCET[]  = {
-  // 1:00 C-Eur CE%sT
-  {
-    &kAtcZonePolicyC_Eur /*zone_policy*/,
-    "CE%T" /*format*/,
-    240 /*offset_code (3600/15)*/,
-    0 /*offset_remainder (3600%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameCET[]  = "CET";
-
-const AtcZoneInfo kAtcZoneCET  = {
-  kAtcZoneNameCET /*name*/,
-  0x0b87d921 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraCET /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: CST6CDT
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraCST6CDT[]  = {
-  // -6:00 US C%sT
-  {
-    &kAtcZonePolicyUS /*zone_policy*/,
-    "C%T" /*format*/,
-    -1440 /*offset_code (-21600/15)*/,
-    0 /*offset_remainder (-21600%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameCST6CDT[]  = "CST6CDT";
-
-const AtcZoneInfo kAtcZoneCST6CDT  = {
-  kAtcZoneNameCST6CDT /*name*/,
-  0xf0e87d00 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraCST6CDT /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: EET
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraEET[]  = {
-  // 2:00 EU EE%sT
-  {
-    &kAtcZonePolicyEU /*zone_policy*/,
-    "EE%T" /*format*/,
-    480 /*offset_code (7200/15)*/,
-    0 /*offset_remainder (7200%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameEET[]  = "EET";
-
-const AtcZoneInfo kAtcZoneEET  = {
-  kAtcZoneNameEET /*name*/,
-  0x0b87e1a3 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraEET /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: EST
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraEST[]  = {
-  // -5:00 - EST
-  {
-    NULL /*zone_policy*/,
-    "EST" /*format*/,
-    -1200 /*offset_code (-18000/15)*/,
-    0 /*offset_remainder (-18000%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameEST[]  = "EST";
-
-const AtcZoneInfo kAtcZoneEST  = {
-  kAtcZoneNameEST /*name*/,
-  0x0b87e371 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraEST /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: EST5EDT
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraEST5EDT[]  = {
-  // -5:00 US E%sT
-  {
-    &kAtcZonePolicyUS /*zone_policy*/,
-    "E%T" /*format*/,
-    -1200 /*offset_code (-18000/15)*/,
-    0 /*offset_remainder (-18000%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameEST5EDT[]  = "EST5EDT";
-
-const AtcZoneInfo kAtcZoneEST5EDT  = {
-  kAtcZoneNameEST5EDT /*name*/,
-  0x8adc72a3 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraEST5EDT /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
 // Zone name: Etc/GMT
 // Zone Eras: 1
 //---------------------------------------------------------------------------
@@ -11657,10 +11446,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_1[]  = {
-  // -1 - -01
+  // -1 - %z
   {
     NULL /*zone_policy*/,
-    "-01" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -11690,10 +11479,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_1  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_10[]  = {
-  // -10 - -10
+  // -10 - %z
   {
     NULL /*zone_policy*/,
-    "-10" /*format*/,
+    "" /*format*/,
     -2400 /*offset_code (-36000/15)*/,
     0 /*offset_remainder (-36000%15)*/,
     0 /*delta_minutes*/,
@@ -11723,10 +11512,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_10  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_11[]  = {
-  // -11 - -11
+  // -11 - %z
   {
     NULL /*zone_policy*/,
-    "-11" /*format*/,
+    "" /*format*/,
     -2640 /*offset_code (-39600/15)*/,
     0 /*offset_remainder (-39600%15)*/,
     0 /*delta_minutes*/,
@@ -11756,10 +11545,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_11  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_12[]  = {
-  // -12 - -12
+  // -12 - %z
   {
     NULL /*zone_policy*/,
-    "-12" /*format*/,
+    "" /*format*/,
     -2880 /*offset_code (-43200/15)*/,
     0 /*offset_remainder (-43200%15)*/,
     0 /*delta_minutes*/,
@@ -11789,10 +11578,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_12  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_2[]  = {
-  // -2 - -02
+  // -2 - %z
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -11822,10 +11611,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_2  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_3[]  = {
-  // -3 - -03
+  // -3 - %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -11855,10 +11644,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_3  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_4[]  = {
-  // -4 - -04
+  // -4 - %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -11888,10 +11677,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_4  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_5[]  = {
-  // -5 - -05
+  // -5 - %z
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -11921,10 +11710,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_5  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_6[]  = {
-  // -6 - -06
+  // -6 - %z
   {
     NULL /*zone_policy*/,
-    "-06" /*format*/,
+    "" /*format*/,
     -1440 /*offset_code (-21600/15)*/,
     0 /*offset_remainder (-21600%15)*/,
     0 /*delta_minutes*/,
@@ -11954,10 +11743,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_6  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_7[]  = {
-  // -7 - -07
+  // -7 - %z
   {
     NULL /*zone_policy*/,
-    "-07" /*format*/,
+    "" /*format*/,
     -1680 /*offset_code (-25200/15)*/,
     0 /*offset_remainder (-25200%15)*/,
     0 /*delta_minutes*/,
@@ -11987,10 +11776,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_7  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_8[]  = {
-  // -8 - -08
+  // -8 - %z
   {
     NULL /*zone_policy*/,
-    "-08" /*format*/,
+    "" /*format*/,
     -1920 /*offset_code (-28800/15)*/,
     0 /*offset_remainder (-28800%15)*/,
     0 /*delta_minutes*/,
@@ -12020,10 +11809,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_8  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_9[]  = {
-  // -9 - -09
+  // -9 - %z
   {
     NULL /*zone_policy*/,
-    "-09" /*format*/,
+    "" /*format*/,
     -2160 /*offset_code (-32400/15)*/,
     0 /*offset_remainder (-32400%15)*/,
     0 /*delta_minutes*/,
@@ -12053,10 +11842,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_9  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_1[]  = {
-  // 1 - +01
+  // 1 - %z
   {
     NULL /*zone_policy*/,
-    "+01" /*format*/,
+    "" /*format*/,
     240 /*offset_code (3600/15)*/,
     0 /*offset_remainder (3600%15)*/,
     0 /*delta_minutes*/,
@@ -12086,10 +11875,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_1  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_10[]  = {
-  // 10 - +10
+  // 10 - %z
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -12119,10 +11908,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_10  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_11[]  = {
-  // 11 - +11
+  // 11 - %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -12152,10 +11941,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_11  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_12[]  = {
-  // 12 - +12
+  // 12 - %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -12185,10 +11974,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_12  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_13[]  = {
-  // 13 - +13
+  // 13 - %z
   {
     NULL /*zone_policy*/,
-    "+13" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -12218,10 +12007,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_13  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_14[]  = {
-  // 14 - +14
+  // 14 - %z
   {
     NULL /*zone_policy*/,
-    "+14" /*format*/,
+    "" /*format*/,
     3360 /*offset_code (50400/15)*/,
     0 /*offset_remainder (50400%15)*/,
     0 /*delta_minutes*/,
@@ -12251,10 +12040,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_14  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_2[]  = {
-  // 2 - +02
+  // 2 - %z
   {
     NULL /*zone_policy*/,
-    "+02" /*format*/,
+    "" /*format*/,
     480 /*offset_code (7200/15)*/,
     0 /*offset_remainder (7200%15)*/,
     0 /*delta_minutes*/,
@@ -12284,10 +12073,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_2  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_3[]  = {
-  // 3 - +03
+  // 3 - %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -12317,10 +12106,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_3  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_4[]  = {
-  // 4 - +04
+  // 4 - %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -12350,10 +12139,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_4  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_5[]  = {
-  // 5 - +05
+  // 5 - %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -12383,10 +12172,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_5  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_6[]  = {
-  // 6 - +06
+  // 6 - %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -12416,10 +12205,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_6  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_7[]  = {
-  // 7 - +07
+  // 7 - %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -12449,10 +12238,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_7  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_8[]  = {
-  // 8 - +08
+  // 8 - %z
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -12482,10 +12271,10 @@ const AtcZoneInfo kAtcZoneEtc_GMT_8  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_9[]  = {
-  // 9 - +09
+  // 9 - %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -12581,10 +12370,10 @@ const AtcZoneInfo kAtcZoneEurope_Andorra  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
-  //              3:00    Russia    +03/+04    2011 Mar 27  2:00s
+  //              3:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -12594,10 +12383,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    2014 Oct 26  2:00s
+  //              4:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -12607,10 +12396,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    -    +03    2016 Mar 27  2:00s
+  //              3:00    -    %z    2016 Mar 27  2:00s
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -12620,10 +12409,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04
+  //              4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -13087,10 +12876,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Istanbul[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -13133,10 +12922,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Kaliningrad[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    -    +03    2014 Oct 26  2:00s
+  //              3:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -13416,10 +13205,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Minsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -13666,10 +13455,10 @@ const AtcZoneInfo kAtcZoneEurope_Rome  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
-  //              4:00    Russia    +04/+05    2010 Mar 28  2:00s
+  //              4:00    Russia    %z    2010 Mar 28  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -13679,10 +13468,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    Russia    +03/+04    2011 Mar 27  2:00s
+  //              3:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -13692,10 +13481,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04
+  //              4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -13725,10 +13514,10 @@ const AtcZoneInfo kAtcZoneEurope_Samara  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
-  //              3:00    Russia    +03/+04    2011 Mar 27  2:00s
+  //              3:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -13738,10 +13527,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    2014 Oct 26  2:00s
+  //              4:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -13751,10 +13540,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    -    +03    2016 Dec  4  2:00s
+  //              3:00    -    %z    2016 Dec  4  2:00s
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -13764,10 +13553,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04
+  //              4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -13981,10 +13770,10 @@ const AtcZoneInfo kAtcZoneEurope_Tirane  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
-  //              3:00    Russia    +03/+04    2011 Mar 27  2:00s
+  //              3:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -13994,10 +13783,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    2014 Oct 26  2:00s
+  //              4:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -14007,10 +13796,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    -    +03    2016 Mar 27  2:00s
+  //              3:00    -    %z    2016 Mar 27  2:00s
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -14020,10 +13809,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04
+  //              4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -14184,10 +13973,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Volgograd[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    2020 Dec 27  2:00s
+  //              4:00    -    %z    2020 Dec 27  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -14291,48 +14080,15 @@ const AtcZoneInfo kAtcZoneEurope_Zurich  = {
 };
 
 //---------------------------------------------------------------------------
-// Zone name: HST
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraHST[]  = {
-  // -10:00 - HST
-  {
-    NULL /*zone_policy*/,
-    "HST" /*format*/,
-    -2400 /*offset_code (-36000/15)*/,
-    0 /*offset_remainder (-36000%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameHST[]  = "HST";
-
-const AtcZoneInfo kAtcZoneHST  = {
-  kAtcZoneNameHST /*name*/,
-  0x0b87f034 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraHST /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
 // Zone name: Indian/Chagos
 // Zone Eras: 1
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraIndian_Chagos[]  = {
-  //             6:00    -    +06
+  //             6:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -14362,10 +14118,10 @@ const AtcZoneInfo kAtcZoneIndian_Chagos  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraIndian_Maldives[]  = {
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -14395,10 +14151,10 @@ const AtcZoneInfo kAtcZoneIndian_Maldives  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraIndian_Mauritius[]  = {
-  //             4:00 Mauritius    +04/+05
+  //             4:00 Mauritius    %z
   {
     &kAtcZonePolicyMauritius /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -14423,147 +14179,15 @@ const AtcZoneInfo kAtcZoneIndian_Mauritius  = {
 };
 
 //---------------------------------------------------------------------------
-// Zone name: MET
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraMET[]  = {
-  // 1:00 C-Eur ME%sT
-  {
-    &kAtcZonePolicyC_Eur /*zone_policy*/,
-    "ME%T" /*format*/,
-    240 /*offset_code (3600/15)*/,
-    0 /*offset_remainder (3600%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameMET[]  = "MET";
-
-const AtcZoneInfo kAtcZoneMET  = {
-  kAtcZoneNameMET /*name*/,
-  0x0b8803ab /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraMET /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: MST
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraMST[]  = {
-  // -7:00 - MST
-  {
-    NULL /*zone_policy*/,
-    "MST" /*format*/,
-    -1680 /*offset_code (-25200/15)*/,
-    0 /*offset_remainder (-25200%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameMST[]  = "MST";
-
-const AtcZoneInfo kAtcZoneMST  = {
-  kAtcZoneNameMST /*name*/,
-  0x0b880579 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraMST /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: MST7MDT
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraMST7MDT[]  = {
-  // -7:00 US M%sT
-  {
-    &kAtcZonePolicyUS /*zone_policy*/,
-    "M%T" /*format*/,
-    -1680 /*offset_code (-25200/15)*/,
-    0 /*offset_remainder (-25200%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameMST7MDT[]  = "MST7MDT";
-
-const AtcZoneInfo kAtcZoneMST7MDT  = {
-  kAtcZoneNameMST7MDT /*name*/,
-  0xf2af9375 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraMST7MDT /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: PST8PDT
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraPST8PDT[]  = {
-  // -8:00 US P%sT
-  {
-    &kAtcZonePolicyUS /*zone_policy*/,
-    "P%T" /*format*/,
-    -1920 /*offset_code (-28800/15)*/,
-    0 /*offset_remainder (-28800%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNamePST8PDT[]  = "PST8PDT";
-
-const AtcZoneInfo kAtcZonePST8PDT  = {
-  kAtcZoneNamePST8PDT /*name*/,
-  0xd99ee2dc /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraPST8PDT /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
 // Zone name: Pacific/Apia
 // Zone Eras: 2
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Apia[]  = {
-  //             -11:00    WS    -11/-10    2011 Dec 29 24:00
+  //             -11:00    WS    %z    2011 Dec 29 24:00
   {
     &kAtcZonePolicyWS /*zone_policy*/,
-    "-11/-10" /*format*/,
+    "" /*format*/,
     -2640 /*offset_code (-39600/15)*/,
     0 /*offset_remainder (-39600%15)*/,
     0 /*delta_minutes*/,
@@ -14573,10 +14197,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Apia[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              13:00    WS    +13/+14
+  //              13:00    WS    %z
   {
     &kAtcZonePolicyWS /*zone_policy*/,
-    "+13/+14" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -14639,10 +14263,10 @@ const AtcZoneInfo kAtcZonePacific_Auckland  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Bougainville[]  = {
-  //             10:00    -    +10    2014 Dec 28  2:00
+  //             10:00    -    %z    2014 Dec 28  2:00
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -14652,10 +14276,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Bougainville[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -14685,10 +14309,10 @@ const AtcZoneInfo kAtcZonePacific_Bougainville  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Chatham[]  = {
-  //             12:45    Chatham    +1245/+1345
+  //             12:45    Chatham    %z
   {
     &kAtcZonePolicyChatham /*zone_policy*/,
-    "+1245/+1345" /*format*/,
+    "" /*format*/,
     3060 /*offset_code (45900/15)*/,
     0 /*offset_remainder (45900%15)*/,
     0 /*delta_minutes*/,
@@ -14718,10 +14342,10 @@ const AtcZoneInfo kAtcZonePacific_Chatham  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Easter[]  = {
-  //             -6:00    Chile    -06/-05
+  //             -6:00    Chile    %z
   {
     &kAtcZonePolicyChile /*zone_policy*/,
-    "-06/-05" /*format*/,
+    "" /*format*/,
     -1440 /*offset_code (-21600/15)*/,
     0 /*offset_remainder (-21600%15)*/,
     0 /*delta_minutes*/,
@@ -14751,10 +14375,10 @@ const AtcZoneInfo kAtcZonePacific_Easter  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Efate[]  = {
-  //             11:00    Vanuatu    +11/+12
+  //             11:00    Vanuatu    %z
   {
     &kAtcZonePolicyVanuatu /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -14784,10 +14408,10 @@ const AtcZoneInfo kAtcZonePacific_Efate  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Fakaofo[]  = {
-  //             -11:00    -    -11    2011 Dec 30
+  //             -11:00    -    %z    2011 Dec 30
   {
     NULL /*zone_policy*/,
-    "-11" /*format*/,
+    "" /*format*/,
     -2640 /*offset_code (-39600/15)*/,
     0 /*offset_remainder (-39600%15)*/,
     0 /*delta_minutes*/,
@@ -14797,10 +14421,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Fakaofo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             13:00    -    +13
+  //             13:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+13" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -14830,10 +14454,10 @@ const AtcZoneInfo kAtcZonePacific_Fakaofo  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Fiji[]  = {
-  //             12:00    Fiji    +12/+13
+  //             12:00    Fiji    %z
   {
     &kAtcZonePolicyFiji /*zone_policy*/,
-    "+12/+13" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -14863,10 +14487,10 @@ const AtcZoneInfo kAtcZonePacific_Fiji  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Galapagos[]  = {
-  //             -6:00    Ecuador    -06/-05
+  //             -6:00    Ecuador    %z
   {
     &kAtcZonePolicyEcuador /*zone_policy*/,
-    "-06/-05" /*format*/,
+    "" /*format*/,
     -1440 /*offset_code (-21600/15)*/,
     0 /*offset_remainder (-21600%15)*/,
     0 /*delta_minutes*/,
@@ -14896,10 +14520,10 @@ const AtcZoneInfo kAtcZonePacific_Galapagos  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Gambier[]  = {
-  //              -9:00    -    -09
+  //              -9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-09" /*format*/,
+    "" /*format*/,
     -2160 /*offset_code (-32400/15)*/,
     0 /*offset_remainder (-32400%15)*/,
     0 /*delta_minutes*/,
@@ -14929,10 +14553,10 @@ const AtcZoneInfo kAtcZonePacific_Gambier  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Guadalcanal[]  = {
-  //             11:00    -    +11
+  //             11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -15041,10 +14665,10 @@ const AtcZoneInfo kAtcZonePacific_Honolulu  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Kanton[]  = {
-  //              13:00    -    +13
+  //              13:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+13" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -15074,10 +14698,10 @@ const AtcZoneInfo kAtcZonePacific_Kanton  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Kiritimati[]  = {
-  //              14:00    -    +14
+  //              14:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+14" /*format*/,
+    "" /*format*/,
     3360 /*offset_code (50400/15)*/,
     0 /*offset_remainder (50400%15)*/,
     0 /*delta_minutes*/,
@@ -15107,10 +14731,10 @@ const AtcZoneInfo kAtcZonePacific_Kiritimati  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Kosrae[]  = {
-  //              12:00    -    +12    1999
+  //              12:00    -    %z    1999
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -15120,10 +14744,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kosrae[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              11:00    -    +11
+  //              11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -15153,10 +14777,10 @@ const AtcZoneInfo kAtcZonePacific_Kosrae  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Kwajalein[]  = {
-  //              12:00    -    +12
+  //              12:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -15186,10 +14810,10 @@ const AtcZoneInfo kAtcZonePacific_Kwajalein  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Marquesas[]  = {
-  //              -9:30    -    -0930
+  //              -9:30    -    %z
   {
     NULL /*zone_policy*/,
-    "-0930" /*format*/,
+    "" /*format*/,
     -2280 /*offset_code (-34200/15)*/,
     0 /*offset_remainder (-34200%15)*/,
     0 /*delta_minutes*/,
@@ -15219,10 +14843,10 @@ const AtcZoneInfo kAtcZonePacific_Marquesas  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Nauru[]  = {
-  //             12:00    -    +12
+  //             12:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -15252,10 +14876,10 @@ const AtcZoneInfo kAtcZonePacific_Nauru  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Niue[]  = {
-  //             -11:00    -    -11
+  //             -11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-11" /*format*/,
+    "" /*format*/,
     -2640 /*offset_code (-39600/15)*/,
     0 /*offset_remainder (-39600%15)*/,
     0 /*delta_minutes*/,
@@ -15285,10 +14909,10 @@ const AtcZoneInfo kAtcZonePacific_Niue  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Norfolk[]  = {
-  //             11:30    -    +1130    2015 Oct  4 02:00s
+  //             11:30    -    %z    2015 Oct  4 02:00s
   {
     NULL /*zone_policy*/,
-    "+1130" /*format*/,
+    "" /*format*/,
     2760 /*offset_code (41400/15)*/,
     0 /*offset_remainder (41400%15)*/,
     0 /*delta_minutes*/,
@@ -15298,10 +14922,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Norfolk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11    2019 Jul
+  //             11:00    -    %z    2019 Jul
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -15311,10 +14935,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Norfolk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    AN    +11/+12
+  //             11:00    AN    %z
   {
     &kAtcZonePolicyAN /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -15344,10 +14968,10 @@ const AtcZoneInfo kAtcZonePacific_Norfolk  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Noumea[]  = {
-  //             11:00    NC    +11/+12
+  //             11:00    NC    %z
   {
     &kAtcZonePolicyNC /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -15410,10 +15034,10 @@ const AtcZoneInfo kAtcZonePacific_Pago_Pago  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Palau[]  = {
-  //               9:00    -    +09
+  //               9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -15443,10 +15067,10 @@ const AtcZoneInfo kAtcZonePacific_Palau  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Pitcairn[]  = {
-  //             -8:00    -    -08
+  //             -8:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-08" /*format*/,
+    "" /*format*/,
     -1920 /*offset_code (-28800/15)*/,
     0 /*offset_remainder (-28800%15)*/,
     0 /*delta_minutes*/,
@@ -15476,10 +15100,10 @@ const AtcZoneInfo kAtcZonePacific_Pitcairn  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Port_Moresby[]  = {
-  //             10:00    -    +10
+  //             10:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -15509,10 +15133,10 @@ const AtcZoneInfo kAtcZonePacific_Port_Moresby  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Rarotonga[]  = {
-  //             -10:00    Cook    -10/-0930
+  //             -10:00    Cook    %z
   {
     &kAtcZonePolicyCook /*zone_policy*/,
-    "-10/-0930" /*format*/,
+    "" /*format*/,
     -2400 /*offset_code (-36000/15)*/,
     0 /*offset_remainder (-36000%15)*/,
     0 /*delta_minutes*/,
@@ -15542,10 +15166,10 @@ const AtcZoneInfo kAtcZonePacific_Rarotonga  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Tahiti[]  = {
-  //             -10:00    -    -10
+  //             -10:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-10" /*format*/,
+    "" /*format*/,
     -2400 /*offset_code (-36000/15)*/,
     0 /*offset_remainder (-36000%15)*/,
     0 /*delta_minutes*/,
@@ -15575,10 +15199,10 @@ const AtcZoneInfo kAtcZonePacific_Tahiti  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Tarawa[]  = {
-  //              12:00    -    +12
+  //              12:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -15608,10 +15232,10 @@ const AtcZoneInfo kAtcZonePacific_Tarawa  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Tongatapu[]  = {
-  //             13:00    -    +13    1999
+  //             13:00    -    %z    1999
   {
     NULL /*zone_policy*/,
-    "+13" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -15621,10 +15245,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Tongatapu[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             13:00    Tonga    +13/+14
+  //             13:00    Tonga    %z
   {
     &kAtcZonePolicyTonga /*zone_policy*/,
-    "+13/+14" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -15648,43 +15272,10 @@ const AtcZoneInfo kAtcZonePacific_Tongatapu  = {
   NULL /*target_info*/,
 };
 
-//---------------------------------------------------------------------------
-// Zone name: WET
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraWET[]  = {
-  // 0:00 EU WE%sT
-  {
-    &kAtcZonePolicyEU /*zone_policy*/,
-    "WE%T" /*format*/,
-    0 /*offset_code (0/15)*/,
-    0 /*offset_remainder (0%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameWET[]  = "WET";
-
-const AtcZoneInfo kAtcZoneWET  = {
-  kAtcZoneNameWET /*name*/,
-  0x0b882e35 /*zone_id*/,
-  &kAtcZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraWET /*eras*/,
-  NULL /*target_info*/,
-};
-
 
 
 //---------------------------------------------------------------------------
-// Links: 245
+// Links: 257
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -17083,6 +16674,21 @@ const AtcZoneInfo kAtcZoneAsia_Calcutta  = {
 };
 
 //---------------------------------------------------------------------------
+// Link name: Asia/Choibalsan -> Asia/Ulaanbaatar
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameAsia_Choibalsan[]  = "Asia/Choibalsan";
+
+const AtcZoneInfo kAtcZoneAsia_Choibalsan  = {
+  kAtcZoneNameAsia_Choibalsan /*name*/,
+  0x928aa4a6 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraAsia_Ulaanbaatar /*eras*/,
+  &kAtcZoneAsia_Ulaanbaatar /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
 // Link name: Asia/Chongqing -> Asia/Shanghai
 //---------------------------------------------------------------------------
 
@@ -17668,6 +17274,36 @@ const AtcZoneInfo kAtcZoneBrazil_West  = {
 };
 
 //---------------------------------------------------------------------------
+// Link name: CET -> Europe/Brussels
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameCET[]  = "CET";
+
+const AtcZoneInfo kAtcZoneCET  = {
+  kAtcZoneNameCET /*name*/,
+  0x0b87d921 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraEurope_Brussels /*eras*/,
+  &kAtcZoneEurope_Brussels /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: CST6CDT -> America/Chicago
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameCST6CDT[]  = "CST6CDT";
+
+const AtcZoneInfo kAtcZoneCST6CDT  = {
+  kAtcZoneNameCST6CDT /*name*/,
+  0xf0e87d00 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraAmerica_Chicago /*eras*/,
+  &kAtcZoneAmerica_Chicago /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
 // Link name: Canada/Atlantic -> America/Halifax
 //---------------------------------------------------------------------------
 
@@ -17830,6 +17466,51 @@ const AtcZoneInfo kAtcZoneCuba  = {
   1 /*num_eras*/,
   kAtcZoneEraAmerica_Havana /*eras*/,
   &kAtcZoneAmerica_Havana /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: EET -> Europe/Athens
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameEET[]  = "EET";
+
+const AtcZoneInfo kAtcZoneEET  = {
+  kAtcZoneNameEET /*name*/,
+  0x0b87e1a3 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraEurope_Athens /*eras*/,
+  &kAtcZoneEurope_Athens /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: EST -> America/Panama
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameEST[]  = "EST";
+
+const AtcZoneInfo kAtcZoneEST  = {
+  kAtcZoneNameEST /*name*/,
+  0x0b87e371 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraAmerica_Panama /*eras*/,
+  &kAtcZoneAmerica_Panama /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: EST5EDT -> America/New_York
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameEST5EDT[]  = "EST5EDT";
+
+const AtcZoneInfo kAtcZoneEST5EDT  = {
+  kAtcZoneNameEST5EDT /*name*/,
+  0x8adc72a3 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraAmerica_New_York /*eras*/,
+  &kAtcZoneAmerica_New_York /*target_info*/,
 };
 
 //---------------------------------------------------------------------------
@@ -18463,6 +18144,21 @@ const AtcZoneInfo kAtcZoneGreenwich  = {
 };
 
 //---------------------------------------------------------------------------
+// Link name: HST -> Pacific/Honolulu
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameHST[]  = "HST";
+
+const AtcZoneInfo kAtcZoneHST  = {
+  kAtcZoneNameHST /*name*/,
+  0x0b87f034 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraPacific_Honolulu /*eras*/,
+  &kAtcZonePacific_Honolulu /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
 // Link name: Hongkong -> Asia/Hong_Kong
 //---------------------------------------------------------------------------
 
@@ -18703,6 +18399,51 @@ const AtcZoneInfo kAtcZoneLibya  = {
 };
 
 //---------------------------------------------------------------------------
+// Link name: MET -> Europe/Brussels
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameMET[]  = "MET";
+
+const AtcZoneInfo kAtcZoneMET  = {
+  kAtcZoneNameMET /*name*/,
+  0x0b8803ab /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraEurope_Brussels /*eras*/,
+  &kAtcZoneEurope_Brussels /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: MST -> America/Phoenix
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameMST[]  = "MST";
+
+const AtcZoneInfo kAtcZoneMST  = {
+  kAtcZoneNameMST /*name*/,
+  0x0b880579 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraAmerica_Phoenix /*eras*/,
+  &kAtcZoneAmerica_Phoenix /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: MST7MDT -> America/Denver
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameMST7MDT[]  = "MST7MDT";
+
+const AtcZoneInfo kAtcZoneMST7MDT  = {
+  kAtcZoneNameMST7MDT /*name*/,
+  0xf2af9375 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraAmerica_Denver /*eras*/,
+  &kAtcZoneAmerica_Denver /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
 // Link name: Mexico/BajaNorte -> America/Tijuana
 //---------------------------------------------------------------------------
 
@@ -18805,6 +18546,21 @@ const AtcZoneInfo kAtcZonePRC  = {
   1 /*num_eras*/,
   kAtcZoneEraAsia_Shanghai /*eras*/,
   &kAtcZoneAsia_Shanghai /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: PST8PDT -> America/Los_Angeles
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNamePST8PDT[]  = "PST8PDT";
+
+const AtcZoneInfo kAtcZonePST8PDT  = {
+  kAtcZoneNamePST8PDT /*name*/,
+  0xd99ee2dc /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraAmerica_Los_Angeles /*eras*/,
+  &kAtcZoneAmerica_Los_Angeles /*target_info*/,
 };
 
 //---------------------------------------------------------------------------
@@ -19345,6 +19101,21 @@ const AtcZoneInfo kAtcZoneW_SU  = {
   3 /*num_eras*/,
   kAtcZoneEraEurope_Moscow /*eras*/,
   &kAtcZoneEurope_Moscow /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: WET -> Europe/Lisbon
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameWET[]  = "WET";
+
+const AtcZoneInfo kAtcZoneWET  = {
+  kAtcZoneNameWET /*name*/,
+  0x0b882e35 /*zone_id*/,
+  &kAtcZoneContext /*zone_context*/,
+  1 /*num_eras*/,
+  kAtcZoneEraEurope_Lisbon /*eras*/,
+  &kAtcZoneEurope_Lisbon /*target_info*/,
 };
 
 //---------------------------------------------------------------------------

--- a/src/zonedb/zone_infos.h
+++ b/src/zonedb/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 657
-//   Policies: 83
-//   Rules: 735
+//   Eras: 644
+//   Policies: 82
+//   Rules: 731
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 8820
-//   Policies: 249
-//   Eras: 9855
-//   Zones: 4563
-//   Links: 3185
+//   Rules: 8772
+//   Policies: 246
+//   Eras: 9660
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 597
+//   Formats: 231
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37599
+//   TOTAL: 36987
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 8820
-//   Policies: 664
-//   Eras: 13140
-//   Zones: 8424
-//   Links: 5880
+//   Rules: 8772
+//   Policies: 656
+//   Eras: 12880
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 597
+//   Formats: 231
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49073
+//   TOTAL: 48391
 //
 // DO NOT EDIT
 
@@ -92,8 +92,8 @@ extern "C" {
 extern const AtcZoneContext kAtcZoneContext;
 
 //---------------------------------------------------------------------------
-// Supported zones: 351
-// Supported eras: 657
+// Supported zones: 339
+// Supported eras: 644
 //---------------------------------------------------------------------------
 
 extern const AtcZoneInfo kAtcZoneAfrica_Abidjan; // Africa/Abidjan
@@ -257,7 +257,6 @@ extern const AtcZoneInfo kAtcZoneAsia_Barnaul; // Asia/Barnaul
 extern const AtcZoneInfo kAtcZoneAsia_Beirut; // Asia/Beirut
 extern const AtcZoneInfo kAtcZoneAsia_Bishkek; // Asia/Bishkek
 extern const AtcZoneInfo kAtcZoneAsia_Chita; // Asia/Chita
-extern const AtcZoneInfo kAtcZoneAsia_Choibalsan; // Asia/Choibalsan
 extern const AtcZoneInfo kAtcZoneAsia_Colombo; // Asia/Colombo
 extern const AtcZoneInfo kAtcZoneAsia_Damascus; // Asia/Damascus
 extern const AtcZoneInfo kAtcZoneAsia_Dhaka; // Asia/Dhaka
@@ -337,11 +336,6 @@ extern const AtcZoneInfo kAtcZoneAustralia_Lord_Howe; // Australia/Lord_Howe
 extern const AtcZoneInfo kAtcZoneAustralia_Melbourne; // Australia/Melbourne
 extern const AtcZoneInfo kAtcZoneAustralia_Perth; // Australia/Perth
 extern const AtcZoneInfo kAtcZoneAustralia_Sydney; // Australia/Sydney
-extern const AtcZoneInfo kAtcZoneCET; // CET
-extern const AtcZoneInfo kAtcZoneCST6CDT; // CST6CDT
-extern const AtcZoneInfo kAtcZoneEET; // EET
-extern const AtcZoneInfo kAtcZoneEST; // EST
-extern const AtcZoneInfo kAtcZoneEST5EDT; // EST5EDT
 extern const AtcZoneInfo kAtcZoneEtc_GMT; // Etc/GMT
 extern const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_1; // Etc/GMT+1
 extern const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_10; // Etc/GMT+10
@@ -408,14 +402,9 @@ extern const AtcZoneInfo kAtcZoneEurope_Vilnius; // Europe/Vilnius
 extern const AtcZoneInfo kAtcZoneEurope_Volgograd; // Europe/Volgograd
 extern const AtcZoneInfo kAtcZoneEurope_Warsaw; // Europe/Warsaw
 extern const AtcZoneInfo kAtcZoneEurope_Zurich; // Europe/Zurich
-extern const AtcZoneInfo kAtcZoneHST; // HST
 extern const AtcZoneInfo kAtcZoneIndian_Chagos; // Indian/Chagos
 extern const AtcZoneInfo kAtcZoneIndian_Maldives; // Indian/Maldives
 extern const AtcZoneInfo kAtcZoneIndian_Mauritius; // Indian/Mauritius
-extern const AtcZoneInfo kAtcZoneMET; // MET
-extern const AtcZoneInfo kAtcZoneMST; // MST
-extern const AtcZoneInfo kAtcZoneMST7MDT; // MST7MDT
-extern const AtcZoneInfo kAtcZonePST8PDT; // PST8PDT
 extern const AtcZoneInfo kAtcZonePacific_Apia; // Pacific/Apia
 extern const AtcZoneInfo kAtcZonePacific_Auckland; // Pacific/Auckland
 extern const AtcZoneInfo kAtcZonePacific_Bougainville; // Pacific/Bougainville
@@ -446,7 +435,6 @@ extern const AtcZoneInfo kAtcZonePacific_Rarotonga; // Pacific/Rarotonga
 extern const AtcZoneInfo kAtcZonePacific_Tahiti; // Pacific/Tahiti
 extern const AtcZoneInfo kAtcZonePacific_Tarawa; // Pacific/Tarawa
 extern const AtcZoneInfo kAtcZonePacific_Tongatapu; // Pacific/Tongatapu
-extern const AtcZoneInfo kAtcZoneWET; // WET
 
 
 // Zone Ids
@@ -612,7 +600,6 @@ extern const AtcZoneInfo kAtcZoneWET; // WET
 #define kAtcZoneIdAsia_Beirut 0xa7f3d5fd /* Asia/Beirut */
 #define kAtcZoneIdAsia_Bishkek 0xb0728553 /* Asia/Bishkek */
 #define kAtcZoneIdAsia_Chita 0x14ae863b /* Asia/Chita */
-#define kAtcZoneIdAsia_Choibalsan 0x928aa4a6 /* Asia/Choibalsan */
 #define kAtcZoneIdAsia_Colombo 0x0af0e91d /* Asia/Colombo */
 #define kAtcZoneIdAsia_Damascus 0x20fbb063 /* Asia/Damascus */
 #define kAtcZoneIdAsia_Dhaka 0x14c07b8b /* Asia/Dhaka */
@@ -692,11 +679,6 @@ extern const AtcZoneInfo kAtcZoneWET; // WET
 #define kAtcZoneIdAustralia_Melbourne 0x0fe559a3 /* Australia/Melbourne */
 #define kAtcZoneIdAustralia_Perth 0x8db8269d /* Australia/Perth */
 #define kAtcZoneIdAustralia_Sydney 0x4d1e9776 /* Australia/Sydney */
-#define kAtcZoneIdCET 0x0b87d921 /* CET */
-#define kAtcZoneIdCST6CDT 0xf0e87d00 /* CST6CDT */
-#define kAtcZoneIdEET 0x0b87e1a3 /* EET */
-#define kAtcZoneIdEST 0x0b87e371 /* EST */
-#define kAtcZoneIdEST5EDT 0x8adc72a3 /* EST5EDT */
 #define kAtcZoneIdEtc_GMT 0xd8e2de58 /* Etc/GMT */
 #define kAtcZoneIdEtc_GMT_PLUS_1 0x9d13da14 /* Etc/GMT+1 */
 #define kAtcZoneIdEtc_GMT_PLUS_10 0x3f8f1cc4 /* Etc/GMT+10 */
@@ -763,14 +745,9 @@ extern const AtcZoneInfo kAtcZoneWET; // WET
 #define kAtcZoneIdEurope_Volgograd 0x3ed0f389 /* Europe/Volgograd */
 #define kAtcZoneIdEurope_Warsaw 0x75185c19 /* Europe/Warsaw */
 #define kAtcZoneIdEurope_Zurich 0x7d8195b9 /* Europe/Zurich */
-#define kAtcZoneIdHST 0x0b87f034 /* HST */
 #define kAtcZoneIdIndian_Chagos 0x456f7c3c /* Indian/Chagos */
 #define kAtcZoneIdIndian_Maldives 0x9869681c /* Indian/Maldives */
 #define kAtcZoneIdIndian_Mauritius 0x7b09c02a /* Indian/Mauritius */
-#define kAtcZoneIdMET 0x0b8803ab /* MET */
-#define kAtcZoneIdMST 0x0b880579 /* MST */
-#define kAtcZoneIdMST7MDT 0xf2af9375 /* MST7MDT */
-#define kAtcZoneIdPST8PDT 0xd99ee2dc /* PST8PDT */
 #define kAtcZoneIdPacific_Apia 0x23359b5e /* Pacific/Apia */
 #define kAtcZoneIdPacific_Auckland 0x25062f86 /* Pacific/Auckland */
 #define kAtcZoneIdPacific_Bougainville 0x5e10f7a4 /* Pacific/Bougainville */
@@ -801,11 +778,10 @@ extern const AtcZoneInfo kAtcZoneWET; // WET
 #define kAtcZoneIdPacific_Tahiti 0xf24c2446 /* Pacific/Tahiti */
 #define kAtcZoneIdPacific_Tarawa 0xf2517e63 /* Pacific/Tarawa */
 #define kAtcZoneIdPacific_Tongatapu 0x262ca836 /* Pacific/Tongatapu */
-#define kAtcZoneIdWET 0x0b882e35 /* WET */
 
 
 //---------------------------------------------------------------------------
-// Supported links: 245
+// Supported links: 257
 //---------------------------------------------------------------------------
 
 extern const AtcZoneInfo kAtcZoneAfrica_Accra; // Africa/Accra -> Africa/Abidjan
@@ -901,6 +877,7 @@ extern const AtcZoneInfo kAtcZoneAsia_Ashkhabad; // Asia/Ashkhabad -> Asia/Ashga
 extern const AtcZoneInfo kAtcZoneAsia_Bahrain; // Asia/Bahrain -> Asia/Qatar
 extern const AtcZoneInfo kAtcZoneAsia_Brunei; // Asia/Brunei -> Asia/Kuching
 extern const AtcZoneInfo kAtcZoneAsia_Calcutta; // Asia/Calcutta -> Asia/Kolkata
+extern const AtcZoneInfo kAtcZoneAsia_Choibalsan; // Asia/Choibalsan -> Asia/Ulaanbaatar
 extern const AtcZoneInfo kAtcZoneAsia_Chongqing; // Asia/Chongqing -> Asia/Shanghai
 extern const AtcZoneInfo kAtcZoneAsia_Chungking; // Asia/Chungking -> Asia/Shanghai
 extern const AtcZoneInfo kAtcZoneAsia_Dacca; // Asia/Dacca -> Asia/Dhaka
@@ -940,6 +917,8 @@ extern const AtcZoneInfo kAtcZoneBrazil_Acre; // Brazil/Acre -> America/Rio_Bran
 extern const AtcZoneInfo kAtcZoneBrazil_DeNoronha; // Brazil/DeNoronha -> America/Noronha
 extern const AtcZoneInfo kAtcZoneBrazil_East; // Brazil/East -> America/Sao_Paulo
 extern const AtcZoneInfo kAtcZoneBrazil_West; // Brazil/West -> America/Manaus
+extern const AtcZoneInfo kAtcZoneCET; // CET -> Europe/Brussels
+extern const AtcZoneInfo kAtcZoneCST6CDT; // CST6CDT -> America/Chicago
 extern const AtcZoneInfo kAtcZoneCanada_Atlantic; // Canada/Atlantic -> America/Halifax
 extern const AtcZoneInfo kAtcZoneCanada_Central; // Canada/Central -> America/Winnipeg
 extern const AtcZoneInfo kAtcZoneCanada_Eastern; // Canada/Eastern -> America/Toronto
@@ -951,6 +930,9 @@ extern const AtcZoneInfo kAtcZoneCanada_Yukon; // Canada/Yukon -> America/Whiteh
 extern const AtcZoneInfo kAtcZoneChile_Continental; // Chile/Continental -> America/Santiago
 extern const AtcZoneInfo kAtcZoneChile_EasterIsland; // Chile/EasterIsland -> Pacific/Easter
 extern const AtcZoneInfo kAtcZoneCuba; // Cuba -> America/Havana
+extern const AtcZoneInfo kAtcZoneEET; // EET -> Europe/Athens
+extern const AtcZoneInfo kAtcZoneEST; // EST -> America/Panama
+extern const AtcZoneInfo kAtcZoneEST5EDT; // EST5EDT -> America/New_York
 extern const AtcZoneInfo kAtcZoneEgypt; // Egypt -> Africa/Cairo
 extern const AtcZoneInfo kAtcZoneEire; // Eire -> Europe/Dublin
 extern const AtcZoneInfo kAtcZoneEtc_GMT_PLUS_0; // Etc/GMT+0 -> Etc/GMT
@@ -993,6 +975,7 @@ extern const AtcZoneInfo kAtcZoneGMT_PLUS_0; // GMT+0 -> Etc/GMT
 extern const AtcZoneInfo kAtcZoneGMT_0; // GMT-0 -> Etc/GMT
 extern const AtcZoneInfo kAtcZoneGMT0; // GMT0 -> Etc/GMT
 extern const AtcZoneInfo kAtcZoneGreenwich; // Greenwich -> Etc/GMT
+extern const AtcZoneInfo kAtcZoneHST; // HST -> Pacific/Honolulu
 extern const AtcZoneInfo kAtcZoneHongkong; // Hongkong -> Asia/Hong_Kong
 extern const AtcZoneInfo kAtcZoneIceland; // Iceland -> Africa/Abidjan
 extern const AtcZoneInfo kAtcZoneIndian_Antananarivo; // Indian/Antananarivo -> Africa/Nairobi
@@ -1009,6 +992,9 @@ extern const AtcZoneInfo kAtcZoneJamaica; // Jamaica -> America/Jamaica
 extern const AtcZoneInfo kAtcZoneJapan; // Japan -> Asia/Tokyo
 extern const AtcZoneInfo kAtcZoneKwajalein; // Kwajalein -> Pacific/Kwajalein
 extern const AtcZoneInfo kAtcZoneLibya; // Libya -> Africa/Tripoli
+extern const AtcZoneInfo kAtcZoneMET; // MET -> Europe/Brussels
+extern const AtcZoneInfo kAtcZoneMST; // MST -> America/Phoenix
+extern const AtcZoneInfo kAtcZoneMST7MDT; // MST7MDT -> America/Denver
 extern const AtcZoneInfo kAtcZoneMexico_BajaNorte; // Mexico/BajaNorte -> America/Tijuana
 extern const AtcZoneInfo kAtcZoneMexico_BajaSur; // Mexico/BajaSur -> America/Mazatlan
 extern const AtcZoneInfo kAtcZoneMexico_General; // Mexico/General -> America/Mexico_City
@@ -1016,6 +1002,7 @@ extern const AtcZoneInfo kAtcZoneNZ; // NZ -> Pacific/Auckland
 extern const AtcZoneInfo kAtcZoneNZ_CHAT; // NZ-CHAT -> Pacific/Chatham
 extern const AtcZoneInfo kAtcZoneNavajo; // Navajo -> America/Denver
 extern const AtcZoneInfo kAtcZonePRC; // PRC -> Asia/Shanghai
+extern const AtcZoneInfo kAtcZonePST8PDT; // PST8PDT -> America/Los_Angeles
 extern const AtcZoneInfo kAtcZonePacific_Chuuk; // Pacific/Chuuk -> Pacific/Port_Moresby
 extern const AtcZoneInfo kAtcZonePacific_Enderbury; // Pacific/Enderbury -> Pacific/Kanton
 extern const AtcZoneInfo kAtcZonePacific_Funafuti; // Pacific/Funafuti -> Pacific/Tarawa
@@ -1052,6 +1039,7 @@ extern const AtcZoneInfo kAtcZoneUS_Samoa; // US/Samoa -> Pacific/Pago_Pago
 extern const AtcZoneInfo kAtcZoneUTC; // UTC -> Etc/UTC
 extern const AtcZoneInfo kAtcZoneUniversal; // Universal -> Etc/UTC
 extern const AtcZoneInfo kAtcZoneW_SU; // W-SU -> Europe/Moscow
+extern const AtcZoneInfo kAtcZoneWET; // WET -> Europe/Lisbon
 extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 
 
@@ -1150,6 +1138,7 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneIdAsia_Bahrain 0x9d078487 /* Asia/Bahrain */
 #define kAtcZoneIdAsia_Brunei 0xa8e595f7 /* Asia/Brunei */
 #define kAtcZoneIdAsia_Calcutta 0x328a44c3 /* Asia/Calcutta */
+#define kAtcZoneIdAsia_Choibalsan 0x928aa4a6 /* Asia/Choibalsan */
 #define kAtcZoneIdAsia_Chongqing 0xf937fb90 /* Asia/Chongqing */
 #define kAtcZoneIdAsia_Chungking 0xc7121dd0 /* Asia/Chungking */
 #define kAtcZoneIdAsia_Dacca 0x14bcac5e /* Asia/Dacca */
@@ -1189,6 +1178,8 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneIdBrazil_DeNoronha 0x9b4cb496 /* Brazil/DeNoronha */
 #define kAtcZoneIdBrazil_East 0x669578c5 /* Brazil/East */
 #define kAtcZoneIdBrazil_West 0x669f689b /* Brazil/West */
+#define kAtcZoneIdCET 0x0b87d921 /* CET */
+#define kAtcZoneIdCST6CDT 0xf0e87d00 /* CST6CDT */
 #define kAtcZoneIdCanada_Atlantic 0x536b119c /* Canada/Atlantic */
 #define kAtcZoneIdCanada_Central 0x626710f5 /* Canada/Central */
 #define kAtcZoneIdCanada_Eastern 0xf3612d5e /* Canada/Eastern */
@@ -1200,6 +1191,9 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneIdChile_Continental 0x7e2bdb18 /* Chile/Continental */
 #define kAtcZoneIdChile_EasterIsland 0xb0982af8 /* Chile/EasterIsland */
 #define kAtcZoneIdCuba 0x7c83cba0 /* Cuba */
+#define kAtcZoneIdEET 0x0b87e1a3 /* EET */
+#define kAtcZoneIdEST 0x0b87e371 /* EST */
+#define kAtcZoneIdEST5EDT 0x8adc72a3 /* EST5EDT */
 #define kAtcZoneIdEgypt 0x0d1a278e /* Egypt */
 #define kAtcZoneIdEire 0x7c84b36a /* Eire */
 #define kAtcZoneIdEtc_GMT_PLUS_0 0x9d13da13 /* Etc/GMT+0 */
@@ -1242,6 +1236,7 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneIdGMT_0 0x0d2f706a /* GMT-0 */
 #define kAtcZoneIdGMT0 0x7c8550fd /* GMT0 */
 #define kAtcZoneIdGreenwich 0xc84d4221 /* Greenwich */
+#define kAtcZoneIdHST 0x0b87f034 /* HST */
 #define kAtcZoneIdHongkong 0x56d36560 /* Hongkong */
 #define kAtcZoneIdIceland 0xe56a35b5 /* Iceland */
 #define kAtcZoneIdIndian_Antananarivo 0x9ebf5289 /* Indian/Antananarivo */
@@ -1258,6 +1253,9 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneIdJapan 0x0d712f8f /* Japan */
 #define kAtcZoneIdKwajalein 0x0e57afbb /* Kwajalein */
 #define kAtcZoneIdLibya 0x0d998b16 /* Libya */
+#define kAtcZoneIdMET 0x0b8803ab /* MET */
+#define kAtcZoneIdMST 0x0b880579 /* MST */
+#define kAtcZoneIdMST7MDT 0xf2af9375 /* MST7MDT */
 #define kAtcZoneIdMexico_BajaNorte 0xfcf7150f /* Mexico/BajaNorte */
 #define kAtcZoneIdMexico_BajaSur 0x08ee3641 /* Mexico/BajaSur */
 #define kAtcZoneIdMexico_General 0x93711d57 /* Mexico/General */
@@ -1265,6 +1263,7 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneIdNZ_CHAT 0x4d42afda /* NZ-CHAT */
 #define kAtcZoneIdNavajo 0xc4ef0e24 /* Navajo */
 #define kAtcZoneIdPRC 0x0b88120a /* PRC */
+#define kAtcZoneIdPST8PDT 0xd99ee2dc /* PST8PDT */
 #define kAtcZoneIdPacific_Chuuk 0x8a090b23 /* Pacific/Chuuk */
 #define kAtcZoneIdPacific_Enderbury 0x61599a93 /* Pacific/Enderbury */
 #define kAtcZoneIdPacific_Funafuti 0xdb402d65 /* Pacific/Funafuti */
@@ -1301,6 +1300,7 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneIdUTC 0x0b882791 /* UTC */
 #define kAtcZoneIdUniversal 0xd0ff523e /* Universal */
 #define kAtcZoneIdW_SU 0x7c8d8ef1 /* W-SU */
+#define kAtcZoneIdWET 0x0b882e35 /* WET */
 #define kAtcZoneIdZulu 0x7c9069b5 /* Zulu */
 
 
@@ -1473,7 +1473,6 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneBufSizeAsia_Beirut 5  /* Asia/Beirut in 1993 */
 #define kAtcZoneBufSizeAsia_Bishkek 5  /* Asia/Bishkek in 1997 */
 #define kAtcZoneBufSizeAsia_Chita 5  /* Asia/Chita in 1987 */
-#define kAtcZoneBufSizeAsia_Choibalsan 5  /* Asia/Choibalsan in 2004 */
 #define kAtcZoneBufSizeAsia_Colombo 2  /* Asia/Colombo in 2006 */
 #define kAtcZoneBufSizeAsia_Damascus 6  /* Asia/Damascus in 2008 */
 #define kAtcZoneBufSizeAsia_Dhaka 4  /* Asia/Dhaka in 2009 */
@@ -1553,11 +1552,6 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneBufSizeAustralia_Melbourne 5  /* Australia/Melbourne in 1993 */
 #define kAtcZoneBufSizeAustralia_Perth 6  /* Australia/Perth in 2007 */
 #define kAtcZoneBufSizeAustralia_Sydney 5  /* Australia/Sydney in 1992 */
-#define kAtcZoneBufSizeCET 5  /* CET in 1983 */
-#define kAtcZoneBufSizeCST6CDT 6  /* CST6CDT in 2008 */
-#define kAtcZoneBufSizeEET 5  /* EET in 1983 */
-#define kAtcZoneBufSizeEST 1  /* EST in 1949 */
-#define kAtcZoneBufSizeEST5EDT 6  /* EST5EDT in 2008 */
 #define kAtcZoneBufSizeEtc_GMT 1  /* Etc/GMT in 1949 */
 #define kAtcZoneBufSizeEtc_GMT_PLUS_1 1  /* Etc/GMT+1 in 1949 */
 #define kAtcZoneBufSizeEtc_GMT_PLUS_10 1  /* Etc/GMT+10 in 1949 */
@@ -1624,14 +1618,9 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneBufSizeEurope_Volgograd 5  /* Europe/Volgograd in 1987 */
 #define kAtcZoneBufSizeEurope_Warsaw 5  /* Europe/Warsaw in 1983 */
 #define kAtcZoneBufSizeEurope_Zurich 5  /* Europe/Zurich in 1983 */
-#define kAtcZoneBufSizeHST 1  /* HST in 1949 */
 #define kAtcZoneBufSizeIndian_Chagos 1  /* Indian/Chagos in 1949 */
 #define kAtcZoneBufSizeIndian_Maldives 1  /* Indian/Maldives in 1949 */
 #define kAtcZoneBufSizeIndian_Mauritius 3  /* Indian/Mauritius in 2008 */
-#define kAtcZoneBufSizeMET 5  /* MET in 1983 */
-#define kAtcZoneBufSizeMST 1  /* MST in 1949 */
-#define kAtcZoneBufSizeMST7MDT 6  /* MST7MDT in 2008 */
-#define kAtcZoneBufSizePST8PDT 6  /* PST8PDT in 2008 */
 #define kAtcZoneBufSizePacific_Apia 5  /* Pacific/Apia in 2011 */
 #define kAtcZoneBufSizePacific_Auckland 5  /* Pacific/Auckland in 1992 */
 #define kAtcZoneBufSizePacific_Bougainville 2  /* Pacific/Bougainville in 2014 */
@@ -1662,7 +1651,6 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 #define kAtcZoneBufSizePacific_Tahiti 1  /* Pacific/Tahiti in 1949 */
 #define kAtcZoneBufSizePacific_Tarawa 1  /* Pacific/Tarawa in 1949 */
 #define kAtcZoneBufSizePacific_Tongatapu 5  /* Pacific/Tongatapu in 1999 */
-#define kAtcZoneBufSizeWET 5  /* WET in 1983 */
 
 
 //---------------------------------------------------------------------------
@@ -1672,16 +1660,18 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 
 
 //---------------------------------------------------------------------------
-// Notable zones: 6
+// Notable zones: 92
 //---------------------------------------------------------------------------
 
 // Africa/Casablanca {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   Morocco {SAVE '-1:00' is a negative DST}
 // }
 // Africa/El_Aaiun {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   Morocco {SAVE '-1:00' is a negative DST}
 // }
-// Africa/Johannesburg {RULES not fixed but FORMAT is missing '%' or '/'}
+// Africa/Johannesburg {RULES not fixed but FORMAT is missing '%s' or '/'}
 // Africa/Windhoek {
 //   Namibia {
 //     LETTER 'CAT' not single character,
@@ -1689,9 +1679,29 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '-1:00' is a negative DST,
 //   }
 // }
+// America/Araguaina {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/Buenos_Aires {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/Catamarca {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/Cordoba {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/Jujuy {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/La_Rioja {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/Mendoza {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/Rio_Gallegos {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/Salta {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/San_Juan {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/San_Luis {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/Tucuman {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Argentina/Ushuaia {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Asuncion {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Bahia {RULES not fixed but FORMAT is missing '%s' or '/'}
 // America/Belize {
 //   Belize {LETTER 'CST' not single character}
 // }
+// America/Boa_Vista {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Bogota {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Campo_Grande {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Cuiaba {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Fortaleza {RULES not fixed but FORMAT is missing '%s' or '/'}
 // America/Goose_Bay {
 //   StJohns {
 //     AT '0:01' not multiple of :15 min,
@@ -1699,9 +1709,21 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
+// America/Guayaquil {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Lima {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Maceio {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Miquelon {RULES not fixed but FORMAT is missing '%s' or '/'}
 // America/Moncton {
 //   Moncton {AT '0:01' not multiple of :15 min}
 // }
+// America/Montevideo {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Noronha {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Nuuk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Punta_Arenas {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Recife {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Santiago {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Sao_Paulo {RULES not fixed but FORMAT is missing '%s' or '/'}
+// America/Scoresbysund {RULES not fixed but FORMAT is missing '%s' or '/'}
 // America/St_Johns {
 //   StJohns {
 //     AT '0:01' not multiple of :15 min,
@@ -1710,6 +1732,7 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Antarctica/Casey {UNTIL '0:01' not multiple of :15 min}
+// Antarctica/Palmer {RULES not fixed but FORMAT is missing '%s' or '/'}
 // Antarctica/Troll {
 //   Troll {
 //     LETTER '+00' not single character,
@@ -1717,6 +1740,17 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
+// Asia/Almaty {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Anadyr {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Aqtau {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Aqtobe {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Atyrau {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Baghdad {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Baku {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Barnaul {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Bishkek {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Chita {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Dhaka {RULES not fixed but FORMAT is missing '%s' or '/'}
 // Asia/Gaza {
 //   UNTIL '0:01' not multiple of :15 min,
 //   Palestine {AT '0:01' not multiple of :15 min}
@@ -1724,15 +1758,61 @@ extern const AtcZoneInfo kAtcZoneZulu; // Zulu -> Etc/UTC
 // Asia/Hebron {
 //   Palestine {AT '0:01' not multiple of :15 min}
 // }
+// Asia/Hovd {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Irkutsk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Kamchatka {RULES not fixed but FORMAT is missing '%s' or '/'}
 // Asia/Kathmandu {STDOFF '5:45' not multiple of :30 min}
-// Australia/Eucla {STDOFF '8:45' not multiple of :30 min}
+// Asia/Khandyga {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Krasnoyarsk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Magadan {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Novokuznetsk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Novosibirsk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Omsk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Oral {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Qostanay {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Qyzylorda {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Sakhalin {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Srednekolymsk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Tbilisi {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Tehran {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Tomsk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Ulaanbaatar {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Ust-Nera {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Vladivostok {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Yakutsk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Yekaterinburg {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Asia/Yerevan {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Atlantic/Azores {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Atlantic/Stanley {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Australia/Eucla {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '8:45' not multiple of :30 min,
+// }
 // Australia/Lord_Howe {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   LH {SAVE '0:30' different from 1:00}
 // }
+// Europe/Astrakhan {RULES not fixed but FORMAT is missing '%s' or '/'}
 // Europe/Dublin {
 //   Eire {SAVE '-1:00' is a negative DST}
 // }
-// Pacific/Chatham {STDOFF '12:45' not multiple of :30 min}
+// Europe/Samara {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Europe/Saratov {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Europe/Ulyanovsk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Indian/Mauritius {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Pacific/Apia {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Pacific/Chatham {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '12:45' not multiple of :30 min,
+// }
+// Pacific/Easter {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Pacific/Efate {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Pacific/Fiji {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Pacific/Galapagos {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Pacific/Norfolk {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Pacific/Noumea {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Pacific/Rarotonga {RULES not fixed but FORMAT is missing '%s' or '/'}
+// Pacific/Tongatapu {RULES not fixed but FORMAT is missing '%s' or '/'}
 
 
 //---------------------------------------------------------------------------

--- a/src/zonedb/zone_policies.c
+++ b/src/zonedb/zone_policies.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,45 +41,45 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 657
-//   Policies: 83
-//   Rules: 735
+//   Eras: 644
+//   Policies: 82
+//   Rules: 731
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 8820
-//   Policies: 249
-//   Eras: 9855
-//   Zones: 4563
-//   Links: 3185
+//   Rules: 8772
+//   Policies: 246
+//   Eras: 9660
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 597
+//   Formats: 231
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37599
+//   TOTAL: 36987
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 8820
-//   Policies: 664
-//   Eras: 13140
-//   Zones: 8424
-//   Links: 5880
+//   Rules: 8772
+//   Policies: 656
+//   Eras: 12880
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 597
+//   Formats: 231
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49073
+//   TOTAL: 48391
 //
 // DO NOT EDIT
 
 #include "zone_policies.h"
 
 //---------------------------------------------------------------------------
-// Policies: 83
-// Rules: 735
+// Policies: 82
+// Rules: 731
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -1222,68 +1222,6 @@ static const AtcZoneRule kAtcZoneRulesBrazil[]  = {
 const AtcZonePolicy kAtcZonePolicyBrazil  = {
   kAtcZoneRulesBrazil /*rules*/,
   21 /*num_rules*/,
-};
-
-//---------------------------------------------------------------------------
-// Policy name: C-Eur
-// Rules: 4
-//---------------------------------------------------------------------------
-
-static const AtcZoneRule kAtcZoneRulesC_Eur[]  = {
-  // Anchor: Rule    C-Eur    1979    1995    -    Sep    lastSun     2:00s    0    -
-  {
-    -32767 /*from_year*/,
-    -32767 /*to_year*/,
-    1 /*in_month*/,
-    0 /*on_day_of_week*/,
-    1 /*on_day_of_month*/,
-    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    0 /*at_time_code (0/15)*/,
-    0 /*delta_minutes*/,
-    0 /*letterIndex ("")*/,
-  },
-  // Rule    C-Eur    1979    1995    -    Sep    lastSun     2:00s    0    -
-  {
-    1979 /*from_year*/,
-    1995 /*to_year*/,
-    9 /*in_month*/,
-    7 /*on_day_of_week*/,
-    0 /*on_day_of_month*/,
-    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    0 /*delta_minutes*/,
-    0 /*letterIndex ("")*/,
-  },
-  // Rule    C-Eur    1981    max    -    Mar    lastSun     2:00s    1:00    S
-  {
-    1981 /*from_year*/,
-    32766 /*to_year*/,
-    3 /*in_month*/,
-    7 /*on_day_of_week*/,
-    0 /*on_day_of_month*/,
-    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    60 /*delta_minutes*/,
-    7 /*letterIndex ("S")*/,
-  },
-  // Rule    C-Eur    1996    max    -    Oct    lastSun     2:00s    0    -
-  {
-    1996 /*from_year*/,
-    32766 /*to_year*/,
-    10 /*in_month*/,
-    7 /*on_day_of_week*/,
-    0 /*on_day_of_month*/,
-    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    0 /*delta_minutes*/,
-    0 /*letterIndex ("")*/,
-  },
-
-};
-
-const AtcZonePolicy kAtcZonePolicyC_Eur  = {
-  kAtcZoneRulesC_Eur /*rules*/,
-  4 /*num_rules*/,
 };
 
 //---------------------------------------------------------------------------

--- a/src/zonedb/zone_policies.h
+++ b/src/zonedb/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 657
-//   Policies: 83
-//   Rules: 735
+//   Eras: 644
+//   Policies: 82
+//   Rules: 731
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 8820
-//   Policies: 249
-//   Eras: 9855
-//   Zones: 4563
-//   Links: 3185
+//   Rules: 8772
+//   Policies: 246
+//   Eras: 9660
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 597
+//   Formats: 231
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37599
+//   TOTAL: 36987
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 8820
-//   Policies: 664
-//   Eras: 13140
-//   Zones: 8424
-//   Links: 5880
+//   Rules: 8772
+//   Policies: 656
+//   Eras: 12880
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 597
+//   Formats: 231
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49073
+//   TOTAL: 48391
 //
 // DO NOT EDIT
 
@@ -85,7 +85,7 @@ extern "C" {
 #endif
 
 //---------------------------------------------------------------------------
-// Supported policies: 83
+// Supported policies: 82
 //---------------------------------------------------------------------------
 
 extern const AtcZonePolicy kAtcZonePolicyAN;
@@ -101,7 +101,6 @@ extern const AtcZonePolicy kAtcZonePolicyAzer;
 extern const AtcZonePolicy kAtcZonePolicyBarb;
 extern const AtcZonePolicy kAtcZonePolicyBelize;
 extern const AtcZonePolicy kAtcZonePolicyBrazil;
-extern const AtcZonePolicy kAtcZonePolicyC_Eur;
 extern const AtcZonePolicy kAtcZonePolicyCO;
 extern const AtcZonePolicy kAtcZonePolicyCR;
 extern const AtcZonePolicy kAtcZonePolicyCanada;
@@ -174,7 +173,7 @@ extern const AtcZonePolicy kAtcZonePolicyZion;
 
 
 //---------------------------------------------------------------------------
-// Unsupported zone policies: 51
+// Unsupported zone policies: 52
 //---------------------------------------------------------------------------
 
 // Albania {unused}
@@ -183,6 +182,7 @@ extern const AtcZonePolicy kAtcZonePolicyZion;
 // Belgium {unused}
 // Bermuda {unused}
 // Bulg {unused}
+// C-Eur {unused}
 // CA {unused}
 // Chicago {unused}
 // Cyprus {unused}

--- a/src/zonedb/zone_registry.c
+++ b/src/zonedb/zone_registry.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 657
-//   Policies: 83
-//   Rules: 735
+//   Eras: 644
+//   Policies: 82
+//   Rules: 731
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 8820
-//   Policies: 249
-//   Eras: 9855
-//   Zones: 4563
-//   Links: 3185
+//   Rules: 8772
+//   Policies: 246
+//   Eras: 9660
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 597
+//   Formats: 231
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37599
+//   TOTAL: 36987
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 8820
-//   Policies: 664
-//   Eras: 13140
-//   Zones: 8424
-//   Links: 5880
+//   Rules: 8772
+//   Policies: 656
+//   Eras: 12880
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 597
+//   Formats: 231
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49073
+//   TOTAL: 48391
 //
 // DO NOT EDIT
 
@@ -81,7 +81,7 @@
 //---------------------------------------------------------------------------
 // Zone Info registry. Sorted by zoneId.
 //---------------------------------------------------------------------------
-const AtcZoneInfo * const kAtcZoneRegistry[351]  = {
+const AtcZoneInfo * const kAtcZoneRegistry[339]  = {
   &kAtcZoneAmerica_St_Johns, // 0x04b14e6e, America/St_Johns
   &kAtcZoneAmerica_North_Dakota_New_Salem, // 0x04f9958e, America/North_Dakota/New_Salem
   &kAtcZoneAsia_Jakarta, // 0x0506ab50, Asia/Jakarta
@@ -92,13 +92,6 @@ const AtcZoneInfo * const kAtcZoneRegistry[351]  = {
   &kAtcZoneAmerica_Indiana_Tell_City, // 0x09263612, America/Indiana/Tell_City
   &kAtcZoneAmerica_Boa_Vista, // 0x0a7b7efe, America/Boa_Vista
   &kAtcZoneAsia_Colombo, // 0x0af0e91d, Asia/Colombo
-  &kAtcZoneCET, // 0x0b87d921, CET
-  &kAtcZoneEET, // 0x0b87e1a3, EET
-  &kAtcZoneEST, // 0x0b87e371, EST
-  &kAtcZoneHST, // 0x0b87f034, HST
-  &kAtcZoneMET, // 0x0b8803ab, MET
-  &kAtcZoneMST, // 0x0b880579, MST
-  &kAtcZoneWET, // 0x0b882e35, WET
   &kAtcZoneAmerica_Guatemala, // 0x0c8259f7, America/Guatemala
   &kAtcZoneAfrica_Monrovia, // 0x0ce90385, Africa/Monrovia
   &kAtcZoneAntarctica_Rothera, // 0x0e86d203, Antarctica/Rothera
@@ -253,7 +246,6 @@ const AtcZoneInfo * const kAtcZoneRegistry[351]  = {
   &kAtcZonePacific_Pitcairn, // 0x8837d8bd, Pacific/Pitcairn
   &kAtcZonePacific_Efate, // 0x8a2bce28, Pacific/Efate
   &kAtcZonePacific_Nauru, // 0x8acc41ae, Pacific/Nauru
-  &kAtcZoneEST5EDT, // 0x8adc72a3, EST5EDT
   &kAtcZonePacific_Palau, // 0x8af04a36, Pacific/Palau
   &kAtcZoneAmerica_Winnipeg, // 0x8c7dafc7, America/Winnipeg
   &kAtcZoneAustralia_Eucla, // 0x8cf99e44, Australia/Eucla
@@ -265,7 +257,6 @@ const AtcZoneInfo * const kAtcZoneRegistry[351]  = {
   &kAtcZonePacific_Norfolk, // 0x8f4eb4be, Pacific/Norfolk
   &kAtcZoneAsia_Yerevan, // 0x9185c8cc, Asia/Yerevan
   &kAtcZoneAmerica_Detroit, // 0x925cfbc1, America/Detroit
-  &kAtcZoneAsia_Choibalsan, // 0x928aa4a6, Asia/Choibalsan
   &kAtcZoneAntarctica_Macquarie, // 0x92f47626, Antarctica/Macquarie
   &kAtcZoneAmerica_Belize, // 0x93256c81, America/Belize
   &kAtcZoneAmerica_Bogota, // 0x93d7bc62, America/Bogota
@@ -384,7 +375,6 @@ const AtcZoneInfo * const kAtcZoneRegistry[351]  = {
   &kAtcZoneEtc_UTC, // 0xd8e31abc, Etc/UTC
   &kAtcZoneAmerica_Yakutat, // 0xd8ee31e9, America/Yakutat
   &kAtcZoneAfrica_Algiers, // 0xd94515c1, Africa/Algiers
-  &kAtcZonePST8PDT, // 0xd99ee2dc, PST8PDT
   &kAtcZoneEurope_Simferopol, // 0xda9eb724, Europe/Simferopol
   &kAtcZoneAmerica_Matamoros, // 0xdd1b0259, America/Matamoros
   &kAtcZonePacific_Kanton, // 0xdd512f0e, Pacific/Kanton
@@ -410,10 +400,8 @@ const AtcZoneInfo * const kAtcZoneRegistry[351]  = {
   &kAtcZoneAmerica_Argentina_Tucuman, // 0xe96399eb, America/Argentina/Tucuman
   &kAtcZoneAsia_Magadan, // 0xebacc19b, Asia/Magadan
   &kAtcZoneAmerica_Ojinaga, // 0xebfde83f, America/Ojinaga
-  &kAtcZoneCST6CDT, // 0xf0e87d00, CST6CDT
   &kAtcZonePacific_Tahiti, // 0xf24c2446, Pacific/Tahiti
   &kAtcZonePacific_Tarawa, // 0xf2517e63, Pacific/Tarawa
-  &kAtcZoneMST7MDT, // 0xf2af9375, MST7MDT
   &kAtcZoneAsia_Tashkent, // 0xf3924254, Asia/Tashkent
   &kAtcZoneAsia_Sakhalin, // 0xf4a1c9bd, Asia/Sakhalin
   &kAtcZonePacific_Guadalcanal, // 0xf4dd25f0, Pacific/Guadalcanal
@@ -465,19 +453,19 @@ const AtcZoneInfo * const kAtcZoneAndLinkRegistry[596]  = {
   &kAtcZoneUS_Hawaii, // 0x09c8de2f, US/Hawaii -> Pacific/Honolulu
   &kAtcZoneAmerica_Boa_Vista, // 0x0a7b7efe, America/Boa_Vista
   &kAtcZoneAsia_Colombo, // 0x0af0e91d, Asia/Colombo
-  &kAtcZoneCET, // 0x0b87d921, CET
-  &kAtcZoneEET, // 0x0b87e1a3, EET
-  &kAtcZoneEST, // 0x0b87e371, EST
+  &kAtcZoneCET, // 0x0b87d921, CET -> Europe/Brussels
+  &kAtcZoneEET, // 0x0b87e1a3, EET -> Europe/Athens
+  &kAtcZoneEST, // 0x0b87e371, EST -> America/Panama
   &kAtcZoneGMT, // 0x0b87eb2d, GMT -> Etc/GMT
-  &kAtcZoneHST, // 0x0b87f034, HST
-  &kAtcZoneMET, // 0x0b8803ab, MET
-  &kAtcZoneMST, // 0x0b880579, MST
+  &kAtcZoneHST, // 0x0b87f034, HST -> Pacific/Honolulu
+  &kAtcZoneMET, // 0x0b8803ab, MET -> Europe/Brussels
+  &kAtcZoneMST, // 0x0b880579, MST -> America/Phoenix
   &kAtcZonePRC, // 0x0b88120a, PRC -> Asia/Shanghai
   &kAtcZoneROC, // 0x0b881a29, ROC -> Asia/Taipei
   &kAtcZoneROK, // 0x0b881a31, ROK -> Asia/Seoul
   &kAtcZoneUCT, // 0x0b882571, UCT -> Etc/UTC
   &kAtcZoneUTC, // 0x0b882791, UTC -> Etc/UTC
-  &kAtcZoneWET, // 0x0b882e35, WET
+  &kAtcZoneWET, // 0x0b882e35, WET -> Europe/Lisbon
   &kAtcZoneAmerica_Guatemala, // 0x0c8259f7, America/Guatemala
   &kAtcZoneEurope_Mariehamn, // 0x0caa6496, Europe/Mariehamn -> Europe/Helsinki
   &kAtcZoneAfrica_Monrovia, // 0x0ce90385, Africa/Monrovia
@@ -753,7 +741,7 @@ const AtcZoneInfo * const kAtcZoneAndLinkRegistry[596]  = {
   &kAtcZoneAustralia_LHI, // 0x8a973e17, Australia/LHI -> Australia/Lord_Howe
   &kAtcZoneAustralia_NSW, // 0x8a974812, Australia/NSW -> Australia/Sydney
   &kAtcZonePacific_Nauru, // 0x8acc41ae, Pacific/Nauru
-  &kAtcZoneEST5EDT, // 0x8adc72a3, EST5EDT
+  &kAtcZoneEST5EDT, // 0x8adc72a3, EST5EDT -> America/New_York
   &kAtcZonePacific_Palau, // 0x8af04a36, Pacific/Palau
   &kAtcZonePacific_Samoa, // 0x8b2699b4, Pacific/Samoa -> Pacific/Pago_Pago
   &kAtcZoneAmerica_Winnipeg, // 0x8c7dafc7, America/Winnipeg
@@ -775,7 +763,7 @@ const AtcZoneInfo * const kAtcZoneAndLinkRegistry[596]  = {
   &kAtcZoneAfrica_Niamey, // 0x914a30fd, Africa/Niamey -> Africa/Lagos
   &kAtcZoneAsia_Yerevan, // 0x9185c8cc, Asia/Yerevan
   &kAtcZoneAmerica_Detroit, // 0x925cfbc1, America/Detroit
-  &kAtcZoneAsia_Choibalsan, // 0x928aa4a6, Asia/Choibalsan
+  &kAtcZoneAsia_Choibalsan, // 0x928aa4a6, Asia/Choibalsan -> Asia/Ulaanbaatar
   &kAtcZoneAntarctica_Macquarie, // 0x92f47626, Antarctica/Macquarie
   &kAtcZoneAmerica_Belize, // 0x93256c81, America/Belize
   &kAtcZoneMexico_General, // 0x93711d57, Mexico/General -> America/Mexico_City
@@ -958,7 +946,7 @@ const AtcZoneInfo * const kAtcZoneAndLinkRegistry[596]  = {
   &kAtcZoneEtc_UTC, // 0xd8e31abc, Etc/UTC
   &kAtcZoneAmerica_Yakutat, // 0xd8ee31e9, America/Yakutat
   &kAtcZoneAfrica_Algiers, // 0xd94515c1, Africa/Algiers
-  &kAtcZonePST8PDT, // 0xd99ee2dc, PST8PDT
+  &kAtcZonePST8PDT, // 0xd99ee2dc, PST8PDT -> America/Los_Angeles
   &kAtcZoneEurope_Bratislava, // 0xda493bed, Europe/Bratislava -> Europe/Prague
   &kAtcZoneEurope_Simferopol, // 0xda9eb724, Europe/Simferopol
   &kAtcZonePacific_Funafuti, // 0xdb402d65, Pacific/Funafuti -> Pacific/Tarawa
@@ -1001,10 +989,10 @@ const AtcZoneInfo * const kAtcZoneAndLinkRegistry[596]  = {
   &kAtcZoneAsia_Magadan, // 0xebacc19b, Asia/Magadan
   &kAtcZoneAmerica_Ojinaga, // 0xebfde83f, America/Ojinaga
   &kAtcZonePacific_Saipan, // 0xeff7a35f, Pacific/Saipan -> Pacific/Guam
-  &kAtcZoneCST6CDT, // 0xf0e87d00, CST6CDT
+  &kAtcZoneCST6CDT, // 0xf0e87d00, CST6CDT -> America/Chicago
   &kAtcZonePacific_Tahiti, // 0xf24c2446, Pacific/Tahiti
   &kAtcZonePacific_Tarawa, // 0xf2517e63, Pacific/Tarawa
-  &kAtcZoneMST7MDT, // 0xf2af9375, MST7MDT
+  &kAtcZoneMST7MDT, // 0xf2af9375, MST7MDT -> America/Denver
   &kAtcZoneCanada_Eastern, // 0xf3612d5e, Canada/Eastern -> America/Toronto
   &kAtcZoneAsia_Tashkent, // 0xf3924254, Asia/Tashkent
   &kAtcZoneAsia_Sakhalin, // 0xf4a1c9bd, Asia/Sakhalin

--- a/src/zonedb/zone_registry.h
+++ b/src/zonedb/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedb
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [2000,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 657
-//   Policies: 83
-//   Rules: 735
+//   Eras: 644
+//   Policies: 82
+//   Rules: 731
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 8820
-//   Policies: 249
-//   Eras: 9855
-//   Zones: 4563
-//   Links: 3185
+//   Rules: 8772
+//   Policies: 246
+//   Eras: 9660
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 597
+//   Formats: 231
 //   Letters: 46
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 37599
+//   TOTAL: 36987
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 8820
-//   Policies: 664
-//   Eras: 13140
-//   Zones: 8424
-//   Links: 5880
+//   Rules: 8772
+//   Policies: 656
+//   Eras: 12880
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 597
+//   Formats: 231
 //   Letters: 64
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 49073
+//   TOTAL: 48391
 //
 // DO NOT EDIT
 
@@ -85,8 +85,8 @@ extern "C" {
 #endif
 
 // Zones
-#define kAtcZoneRegistrySize 351
-extern const AtcZoneInfo * const kAtcZoneRegistry[351];
+#define kAtcZoneRegistrySize 339
+extern const AtcZoneInfo * const kAtcZoneRegistry[339];
 
 // Zones and Links
 #define kAtcZoneAndLinkRegistrySize 596

--- a/src/zonedball/Makefile
+++ b/src/zonedball/Makefile
@@ -8,7 +8,7 @@ zone_registry.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2024a
+TZ_VERSION := 2024b
 START_YEAR := 1800
 UNTIL_YEAR := 2200
 

--- a/src/zonedball/zone_infos.c
+++ b/src/zonedball/zone_infos.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1963
+//   Eras: 1941
 //   Policies: 134
-//   Rules: 2234
+//   Rules: 2231
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 402
-//   Eras: 29445
-//   Zones: 4563
-//   Links: 3185
+//   Eras: 29115
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75879
+//   TOTAL: 74967
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 1072
-//   Eras: 39260
-//   Zones: 8424
-//   Links: 5880
+//   Eras: 38820
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94176
+//   TOTAL: 93154
 //
 // DO NOT EDIT
 
@@ -82,7 +82,7 @@
 // ZoneContext
 //---------------------------------------------------------------------------
 
-static const char kAtcTzDatabaseVersion[] = "2024a";
+static const char kAtcTzDatabaseVersion[] = "2024b";
 
 static const char * const kAtcFragments[] = {
 /*\x00*/ NULL,
@@ -135,8 +135,8 @@ const AtcZoneContext kAtcAllZoneContext = {
 };
 
 //---------------------------------------------------------------------------
-// Zones: 351
-// Eras: 1963
+// Zones: 339
+// Eras: 1941
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -354,10 +354,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Bissau[]  = {
     240 /*until_time_code (3600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -1:00    -    -01    1975
+  //             -1:00    -    %z    1975
   {
     NULL /*zone_policy*/,
-    "-01" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -459,10 +459,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Casablanca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              0:00    Morocco    +00/+01    1984 Mar 16
+  //              0:00    Morocco    %z    1984 Mar 16
   {
     &kAtcAllZonePolicyMorocco /*zone_policy*/,
-    "+00/+01" /*format*/,
+    "" /*format*/,
     0 /*offset_code (0/15)*/,
     0 /*offset_remainder (0%15)*/,
     0 /*delta_minutes*/,
@@ -472,10 +472,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Casablanca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              1:00    -    +01    1986
+  //              1:00    -    %z    1986
   {
     NULL /*zone_policy*/,
-    "+01" /*format*/,
+    "" /*format*/,
     240 /*offset_code (3600/15)*/,
     0 /*offset_remainder (3600%15)*/,
     0 /*delta_minutes*/,
@@ -485,10 +485,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Casablanca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              0:00    Morocco    +00/+01    2018 Oct 28  3:00
+  //              0:00    Morocco    %z    2018 Oct 28  3:00
   {
     &kAtcAllZonePolicyMorocco /*zone_policy*/,
-    "+00/+01" /*format*/,
+    "" /*format*/,
     0 /*offset_code (0/15)*/,
     0 /*offset_remainder (0%15)*/,
     0 /*delta_minutes*/,
@@ -498,10 +498,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Casablanca[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              1:00    Morocco    +01/+00
+  //              1:00    Morocco    %z
   {
     &kAtcAllZonePolicyMorocco /*zone_policy*/,
-    "+01/+00" /*format*/,
+    "" /*format*/,
     240 /*offset_code (3600/15)*/,
     0 /*offset_remainder (3600%15)*/,
     0 /*delta_minutes*/,
@@ -681,10 +681,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_El_Aaiun[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -1:00    -    -01    1976 Apr 14
+  //             -1:00    -    %z    1976 Apr 14
   {
     NULL /*zone_policy*/,
-    "-01" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -694,10 +694,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_El_Aaiun[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              0:00    Morocco    +00/+01    2018 Oct 28  3:00
+  //              0:00    Morocco    %z    2018 Oct 28  3:00
   {
     &kAtcAllZonePolicyMorocco /*zone_policy*/,
-    "+00/+01" /*format*/,
+    "" /*format*/,
     0 /*offset_code (0/15)*/,
     0 /*offset_remainder (0%15)*/,
     0 /*delta_minutes*/,
@@ -707,10 +707,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_El_Aaiun[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              1:00    Morocco    +01/+00
+  //              1:00    Morocco    %z
   {
     &kAtcAllZonePolicyMorocco /*zone_policy*/,
-    "+01/+00" /*format*/,
+    "" /*format*/,
     240 /*offset_code (3600/15)*/,
     0 /*offset_remainder (3600%15)*/,
     0 /*delta_minutes*/,
@@ -982,10 +982,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Lagos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             0:30    -    +0030    1919 Sep  1
+  //             0:30    -    %z    1919 Sep  1
   {
     NULL /*zone_policy*/,
-    "+0030" /*format*/,
+    "" /*format*/,
     120 /*offset_code (1800/15)*/,
     0 /*offset_remainder (1800%15)*/,
     0 /*delta_minutes*/,
@@ -1028,15 +1028,15 @@ const AtcZoneInfo kAtcAllZoneAfrica_Lagos  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAfrica_Maputo[]  = {
-  // 2:10:20 - LMT 1903 Mar
+  // 2:10:18 - LMT 1909
   {
     NULL /*zone_policy*/,
     "LMT" /*format*/,
-    521 /*offset_code (7820/15)*/,
-    5 /*offset_remainder (7820%15)*/,
+    521 /*offset_code (7818/15)*/,
+    3 /*offset_remainder (7818%15)*/,
     0 /*delta_minutes*/,
-    1903 /*until_year*/,
-    3 /*until_month*/,
+    1909 /*until_year*/,
+    1 /*until_month*/,
     1 /*until_day*/,
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
@@ -1159,10 +1159,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Nairobi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             2:30    -    +0230    1928 Jun 30 24:00
+  //             2:30    -    %z    1928 Jun 30 24:00
   {
     NULL /*zone_policy*/,
-    "+0230" /*format*/,
+    "" /*format*/,
     600 /*offset_code (9000/15)*/,
     0 /*offset_remainder (9000%15)*/,
     0 /*delta_minutes*/,
@@ -1185,10 +1185,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Nairobi[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             2:30    -    +0230    1936 Dec 31 24:00
+  //             2:30    -    %z    1936 Dec 31 24:00
   {
     NULL /*zone_policy*/,
-    "+0230" /*format*/,
+    "" /*format*/,
     600 /*offset_code (9000/15)*/,
     0 /*offset_remainder (9000%15)*/,
     0 /*delta_minutes*/,
@@ -1198,10 +1198,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Nairobi[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             2:45    -    +0245    1942 Jul 31 24:00
+  //             2:45    -    %z    1942 Jul 31 24:00
   {
     NULL /*zone_policy*/,
-    "+0245" /*format*/,
+    "" /*format*/,
     660 /*offset_code (9900/15)*/,
     0 /*offset_remainder (9900%15)*/,
     0 /*delta_minutes*/,
@@ -1610,10 +1610,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Windhoek[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             1:30    -    +0130    1903 Mar
+  //             1:30    -    %z    1903 Mar
   {
     NULL /*zone_policy*/,
-    "+0130" /*format*/,
+    "" /*format*/,
     360 /*offset_code (5400/15)*/,
     0 /*offset_remainder (5400%15)*/,
     0 /*delta_minutes*/,
@@ -1969,10 +1969,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Araguaina[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    1990 Sep 17
+  //             -3:00    Brazil    %z    1990 Sep 17
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1982,10 +1982,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Araguaina[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1995 Sep 14
+  //             -3:00    -    %z    1995 Sep 14
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -1995,10 +1995,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Araguaina[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2003 Sep 24
+  //             -3:00    Brazil    %z    2003 Sep 24
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2008,10 +2008,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Araguaina[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2012 Oct 21
+  //             -3:00    -    %z    2012 Oct 21
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2021,10 +2021,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Araguaina[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2013 Sep
+  //             -3:00    Brazil    %z    2013 Sep
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2034,10 +2034,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Araguaina[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2093,10 +2093,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Buenos_Aires[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2106,10 +2106,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Buenos_Aires[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2119,10 +2119,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Buenos_Aires[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2132,10 +2132,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Buenos_Aires[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2145,10 +2145,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Buenos_Aires[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02
+  //             -3:00    Arg    %z
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2204,10 +2204,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2217,10 +2217,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2230,10 +2230,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1991 Mar  3
+  //             -3:00    Arg    %z    1991 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2243,10 +2243,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1991 Oct 20
+  //             -4:00    -    %z    1991 Oct 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2256,10 +2256,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2269,10 +2269,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2282,10 +2282,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 Jun  1
+  //             -3:00    -    %z    2004 Jun  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2295,10 +2295,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jun 20
+  //             -4:00    -    %z    2004 Jun 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2308,10 +2308,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2321,10 +2321,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Catamarca[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2380,10 +2380,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Cordoba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2393,10 +2393,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Cordoba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2406,10 +2406,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Cordoba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1991 Mar  3
+  //             -3:00    Arg    %z    1991 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2419,10 +2419,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Cordoba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1991 Oct 20
+  //             -4:00    -    %z    1991 Oct 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2432,10 +2432,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Cordoba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2445,10 +2445,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Cordoba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2458,10 +2458,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Cordoba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02
+  //             -3:00    Arg    %z
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2517,10 +2517,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2530,10 +2530,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2543,10 +2543,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1990 Mar  4
+  //             -3:00    Arg    %z    1990 Mar  4
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2556,10 +2556,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1990 Oct 28
+  //             -4:00    -    %z    1990 Oct 28
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2569,10 +2569,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    1:00    -03    1991 Mar 17
+  //             -4:00    1:00    %z    1991 Mar 17
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     60 /*delta_minutes*/,
@@ -2582,10 +2582,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1991 Oct  6
+  //             -4:00    -    %z    1991 Oct  6
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2595,10 +2595,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    1:00    -02    1992
+  //             -3:00    1:00    %z    1992
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     60 /*delta_minutes*/,
@@ -2608,10 +2608,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2621,10 +2621,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2634,10 +2634,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2647,10 +2647,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Jujuy[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2706,10 +2706,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2719,10 +2719,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2732,10 +2732,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1991 Mar  1
+  //             -3:00    Arg    %z    1991 Mar  1
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2745,10 +2745,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1991 May  7
+  //             -4:00    -    %z    1991 May  7
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2758,10 +2758,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2771,10 +2771,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2784,10 +2784,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 Jun  1
+  //             -3:00    -    %z    2004 Jun  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2797,10 +2797,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jun 20
+  //             -4:00    -    %z    2004 Jun 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2810,10 +2810,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2823,10 +2823,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_La_Rioja[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2882,10 +2882,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2895,10 +2895,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2908,10 +2908,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1990 Mar  4
+  //             -3:00    Arg    %z    1990 Mar  4
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2921,10 +2921,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1990 Oct 15
+  //             -4:00    -    %z    1990 Oct 15
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2934,10 +2934,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    1:00    -03    1991 Mar  1
+  //             -4:00    1:00    %z    1991 Mar  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     60 /*delta_minutes*/,
@@ -2947,10 +2947,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1991 Oct 15
+  //             -4:00    -    %z    1991 Oct 15
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2960,10 +2960,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    1:00    -03    1992 Mar  1
+  //             -4:00    1:00    %z    1992 Mar  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     60 /*delta_minutes*/,
@@ -2973,10 +2973,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1992 Oct 18
+  //             -4:00    -    %z    1992 Oct 18
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -2986,10 +2986,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -2999,10 +2999,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3012,10 +3012,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 May 23
+  //             -3:00    -    %z    2004 May 23
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3025,10 +3025,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Sep 26
+  //             -4:00    -    %z    2004 Sep 26
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3038,10 +3038,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3051,10 +3051,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Mendoza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3110,10 +3110,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3123,10 +3123,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3136,10 +3136,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3149,10 +3149,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3162,10 +3162,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 Jun  1
+  //             -3:00    -    %z    2004 Jun  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3175,10 +3175,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jun 20
+  //             -4:00    -    %z    2004 Jun 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3188,10 +3188,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3201,10 +3201,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Rio_Gallegos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3260,10 +3260,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3273,10 +3273,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3286,10 +3286,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1991 Mar  3
+  //             -3:00    Arg    %z    1991 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3299,10 +3299,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1991 Oct 20
+  //             -4:00    -    %z    1991 Oct 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3312,10 +3312,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3325,10 +3325,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3338,10 +3338,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3351,10 +3351,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Salta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3410,10 +3410,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3423,10 +3423,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3436,10 +3436,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1991 Mar  1
+  //             -3:00    Arg    %z    1991 Mar  1
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3449,10 +3449,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1991 May  7
+  //             -4:00    -    %z    1991 May  7
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3462,10 +3462,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3475,10 +3475,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3488,10 +3488,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 May 31
+  //             -3:00    -    %z    2004 May 31
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3501,10 +3501,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jul 25
+  //             -4:00    -    %z    2004 Jul 25
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3514,10 +3514,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3527,10 +3527,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Juan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3586,10 +3586,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3599,10 +3599,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3612,10 +3612,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1990
+  //             -3:00    Arg    %z    1990
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3625,10 +3625,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    1:00    -02    1990 Mar 14
+  //             -3:00    1:00    %z    1990 Mar 14
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     60 /*delta_minutes*/,
@@ -3638,10 +3638,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1990 Oct 15
+  //             -4:00    -    %z    1990 Oct 15
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3651,10 +3651,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    1:00    -03    1991 Mar  1
+  //             -4:00    1:00    %z    1991 Mar  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     60 /*delta_minutes*/,
@@ -3664,10 +3664,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1991 Jun  1
+  //             -4:00    -    %z    1991 Jun  1
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3677,10 +3677,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1999 Oct  3
+  //             -3:00    -    %z    1999 Oct  3
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3690,10 +3690,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    1:00    -03    2000 Mar  3
+  //             -4:00    1:00    %z    2000 Mar  3
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     60 /*delta_minutes*/,
@@ -3703,10 +3703,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 May 31
+  //             -3:00    -    %z    2004 May 31
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3716,10 +3716,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jul 25
+  //             -4:00    -    %z    2004 Jul 25
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3729,10 +3729,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Jan 21
+  //             -3:00    Arg    %z    2008 Jan 21
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3742,10 +3742,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    SanLuis    -04/-03    2009 Oct 11
+  //             -4:00    SanLuis    %z    2009 Oct 11
   {
     &kAtcAllZonePolicySanLuis /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3755,10 +3755,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_San_Luis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3814,10 +3814,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3827,10 +3827,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3840,10 +3840,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1991 Mar  3
+  //             -3:00    Arg    %z    1991 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3853,10 +3853,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1991 Oct 20
+  //             -4:00    -    %z    1991 Oct 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3866,10 +3866,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3879,10 +3879,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3892,10 +3892,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 Jun  1
+  //             -3:00    -    %z    2004 Jun  1
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3905,10 +3905,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jun 13
+  //             -4:00    -    %z    2004 Jun 13
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3918,10 +3918,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Tucuman[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02
+  //             -3:00    Arg    %z
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -3977,10 +3977,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1930 Dec
+  //             -4:00    -    %z    1930 Dec
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -3990,10 +3990,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4003,10 +4003,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1999 Oct  3
+  //             -3:00    Arg    %z    1999 Oct  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4016,10 +4016,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    2000 Mar  3
+  //             -4:00    Arg    %z    2000 Mar  3
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4029,10 +4029,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2004 May 30
+  //             -3:00    -    %z    2004 May 30
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4042,10 +4042,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Jun 20
+  //             -4:00    -    %z    2004 Jun 20
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4055,10 +4055,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    2008 Oct 18
+  //             -3:00    Arg    %z    2008 Oct 18
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4068,10 +4068,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Argentina_Ushuaia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4127,10 +4127,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Asuncion[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1972 Oct
+  //             -4:00    -    %z    1972 Oct
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4140,10 +4140,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Asuncion[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1974 Apr
+  //             -3:00    -    %z    1974 Apr
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4153,10 +4153,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Asuncion[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Para    -04/-03
+  //             -4:00    Para    %z
   {
     &kAtcAllZonePolicyPara /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4199,10 +4199,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bahia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2003 Sep 24
+  //             -3:00    Brazil    %z    2003 Sep 24
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4212,10 +4212,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bahia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2011 Oct 16
+  //             -3:00    -    %z    2011 Oct 16
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4225,10 +4225,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bahia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2012 Oct 21
+  //             -3:00    Brazil    %z    2012 Oct 21
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4238,10 +4238,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bahia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4267,7 +4267,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Bahia  = {
 
 //---------------------------------------------------------------------------
 // Zone name: America/Bahia_Banderas
-// Zone Eras: 9
+// Zone Eras: 8
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Bahia_Banderas[]  = {
@@ -4284,7 +4284,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bahia_Banderas[]  = {
     1680 /*until_time_code (25200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -7:00    -    MST    1927 Jun 10 23:00
+  //             -7:00    -    MST    1927 Jun 10
   {
     NULL /*zone_policy*/,
     "MST" /*format*/,
@@ -4294,7 +4294,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bahia_Banderas[]  = {
     1927 /*until_year*/,
     6 /*until_month*/,
     10 /*until_day*/,
-    5520 /*until_time_code (82800/15)*/,
+    0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -6:00    -    CST    1930 Nov 15
@@ -4336,25 +4336,12 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bahia_Banderas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -7:00    -    MST    1949 Jan 14
+  //             -7:00    -    MST    1970
   {
     NULL /*zone_policy*/,
     "MST" /*format*/,
     -1680 /*offset_code (-25200/15)*/,
     0 /*offset_remainder (-25200%15)*/,
-    0 /*delta_minutes*/,
-    1949 /*until_year*/,
-    1 /*until_month*/,
-    14 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-  //             -8:00    -    PST    1970
-  {
-    NULL /*zone_policy*/,
-    "PST" /*format*/,
-    -1920 /*offset_code (-28800/15)*/,
-    0 /*offset_remainder (-28800%15)*/,
     0 /*delta_minutes*/,
     1970 /*until_year*/,
     1 /*until_month*/,
@@ -4397,7 +4384,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Bahia_Banderas  = {
   kAtcZoneNameAmerica_Bahia_Banderas /*name*/,
   0x14f6329a /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  9 /*num_eras*/,
+  8 /*num_eras*/,
   kAtcZoneEraAmerica_Bahia_Banderas /*eras*/,
   NULL /*target_info*/,
 };
@@ -4493,10 +4480,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Belem[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    1988 Sep 12
+  //             -3:00    Brazil    %z    1988 Sep 12
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4506,10 +4493,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Belem[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -4598,10 +4585,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Boa_Vista[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03    1988 Sep 12
+  //             -4:00    Brazil    %z    1988 Sep 12
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4611,10 +4598,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Boa_Vista[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1999 Sep 30
+  //             -4:00    -    %z    1999 Sep 30
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4624,10 +4611,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Boa_Vista[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03    2000 Oct 15
+  //             -4:00    Brazil    %z    2000 Oct 15
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4637,10 +4624,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Boa_Vista[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4696,10 +4683,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Bogota[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    CO    -05/-04
+  //             -5:00    CO    %z
   {
     &kAtcAllZonePolicyCO /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -4925,10 +4912,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Campo_Grande[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03
+  //             -4:00    Brazil    %z
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -4954,7 +4941,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Campo_Grande  = {
 
 //---------------------------------------------------------------------------
 // Zone name: America/Cancun
-// Zone Eras: 5
+// Zone Eras: 7
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Cancun[]  = {
@@ -4971,7 +4958,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Cancun[]  = {
     1440 /*until_time_code (21600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -6:00    -    CST    1981 Dec 23
+  //             -6:00    -    CST    1981 Dec 26  2:00
   {
     NULL /*zone_policy*/,
     "CST" /*format*/,
@@ -4980,8 +4967,34 @@ static const AtcZoneEra kAtcZoneEraAmerica_Cancun[]  = {
     0 /*delta_minutes*/,
     1981 /*until_year*/,
     12 /*until_month*/,
-    23 /*until_day*/,
+    26 /*until_day*/,
+    480 /*until_time_code (7200/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -5:00    -    EST    1983 Jan  4  0:00
+  {
+    NULL /*zone_policy*/,
+    "EST" /*format*/,
+    -1200 /*offset_code (-18000/15)*/,
+    0 /*offset_remainder (-18000%15)*/,
+    0 /*delta_minutes*/,
+    1983 /*until_year*/,
+    1 /*until_month*/,
+    4 /*until_day*/,
     0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -6:00    Mexico    C%sT    1997 Oct 26  2:00
+  {
+    &kAtcAllZonePolicyMexico /*zone_policy*/,
+    "C%T" /*format*/,
+    -1440 /*offset_code (-21600/15)*/,
+    0 /*offset_remainder (-21600%15)*/,
+    0 /*delta_minutes*/,
+    1997 /*until_year*/,
+    10 /*until_month*/,
+    26 /*until_day*/,
+    480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -5:00    Mexico    E%sT    1998 Aug  2  2:00
@@ -5032,7 +5045,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Cancun  = {
   kAtcZoneNameAmerica_Cancun /*name*/,
   0x953331be /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  5 /*num_eras*/,
+  7 /*num_eras*/,
   kAtcZoneEraAmerica_Cancun /*eras*/,
   NULL /*target_info*/,
 };
@@ -5069,10 +5082,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Caracas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:30    -    -0430    1965 Jan  1  0:00
+  //             -4:30    -    %z    1965 Jan  1  0:00
   {
     NULL /*zone_policy*/,
-    "-0430" /*format*/,
+    "" /*format*/,
     -1080 /*offset_code (-16200/15)*/,
     0 /*offset_remainder (-16200%15)*/,
     0 /*delta_minutes*/,
@@ -5082,10 +5095,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Caracas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2007 Dec  9  3:00
+  //             -4:00    -    %z    2007 Dec  9  3:00
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -5095,10 +5108,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Caracas[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:30    -    -0430    2016 May  1  2:30
+  //             -4:30    -    %z    2016 May  1  2:30
   {
     NULL /*zone_policy*/,
-    "-0430" /*format*/,
+    "" /*format*/,
     -1080 /*offset_code (-16200/15)*/,
     0 /*offset_remainder (-16200%15)*/,
     0 /*delta_minutes*/,
@@ -5108,10 +5121,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Caracas[]  = {
     600 /*until_time_code (9000/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -5154,10 +5167,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Cayenne[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1967 Oct
+  //             -4:00    -    %z    1967 Oct
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -5167,10 +5180,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Cayenne[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5337,7 +5350,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Chihuahua[]  = {
     1680 /*until_time_code (25200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -7:00    -    MST    1927 Jun 10 23:00
+  //             -7:00    -    MST    1927 Jun 10
   {
     NULL /*zone_policy*/,
     "MST" /*format*/,
@@ -5347,7 +5360,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Chihuahua[]  = {
     1927 /*until_year*/,
     6 /*until_month*/,
     10 /*until_day*/,
-    5520 /*until_time_code (82800/15)*/,
+    0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -6:00    -    CST    1930 Nov 15
@@ -5474,7 +5487,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Ciudad_Juarez[]  = {
     1680 /*until_time_code (25200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -7:00    -    MST    1927 Jun 10 23:00
+  //             -7:00    -    MST    1927 Jun 10
   {
     NULL /*zone_policy*/,
     "MST" /*format*/,
@@ -5484,7 +5497,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Ciudad_Juarez[]  = {
     1927 /*until_year*/,
     6 /*until_month*/,
     10 /*until_day*/,
-    5520 /*until_time_code (82800/15)*/,
+    0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -6:00    -    CST    1930 Nov 15
@@ -5696,10 +5709,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Cuiaba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03    2003 Sep 24
+  //             -4:00    Brazil    %z    2003 Sep 24
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -5709,10 +5722,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Cuiaba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2004 Oct  1
+  //             -4:00    -    %z    2004 Oct  1
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -5722,10 +5735,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Cuiaba[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03
+  //             -4:00    Brazil    %z
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -5768,10 +5781,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Danmarkshavn[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1980 Apr  6  2:00
+  //             -3:00    -    %z    1980 Apr  6  2:00
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -5781,10 +5794,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Danmarkshavn[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    EU    -03/-02    1996
+  //             -3:00    EU    %z    1996
   {
     &kAtcAllZonePolicyEU /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -6317,10 +6330,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Eirunepe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    Brazil    -05/-04    1988 Sep 12
+  //             -5:00    Brazil    %z    1988 Sep 12
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -6330,10 +6343,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Eirunepe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05    1993 Sep 28
+  //             -5:00    -    %z    1993 Sep 28
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -6343,10 +6356,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Eirunepe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    Brazil    -05/-04    1994 Sep 22
+  //             -5:00    Brazil    %z    1994 Sep 22
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -6356,10 +6369,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Eirunepe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05    2008 Jun 24  0:00
+  //             -5:00    -    %z    2008 Jun 24  0:00
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -6369,10 +6382,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Eirunepe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2013 Nov 10
+  //             -4:00    -    %z    2013 Nov 10
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -6382,10 +6395,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Eirunepe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05
+  //             -5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -6572,10 +6585,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    1990 Sep 17
+  //             -3:00    Brazil    %z    1990 Sep 17
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -6585,10 +6598,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1999 Sep 30
+  //             -3:00    -    %z    1999 Sep 30
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -6598,10 +6611,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2000 Oct 22
+  //             -3:00    Brazil    %z    2000 Oct 22
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -6611,10 +6624,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2001 Sep 13
+  //             -3:00    -    %z    2001 Sep 13
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -6624,10 +6637,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2002 Oct  1
+  //             -3:00    Brazil    %z    2002 Oct  1
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -6637,10 +6650,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Fortaleza[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -7088,10 +7101,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Guayaquil[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    Ecuador    -05/-04
+  //             -5:00    Ecuador    %z
   {
     &kAtcAllZonePolicyEcuador /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -7134,10 +7147,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Guyana[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1915 Mar  1
+  //             -4:00    -    %z    1915 Mar  1
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -7147,10 +7160,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Guyana[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:45    -    -0345    1975 Aug  1
+  //             -3:45    -    %z    1975 Aug  1
   {
     NULL /*zone_policy*/,
-    "-0345" /*format*/,
+    "" /*format*/,
     -900 /*offset_code (-13500/15)*/,
     0 /*offset_remainder (-13500%15)*/,
     0 /*delta_minutes*/,
@@ -7160,10 +7173,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Guyana[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1992 Mar 29  1:00
+  //             -3:00    -    %z    1992 Mar 29  1:00
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -7173,10 +7186,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Guyana[]  = {
     240 /*until_time_code (3600/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -7372,7 +7385,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Havana  = {
 
 //---------------------------------------------------------------------------
 // Zone name: America/Hermosillo
-// Zone Eras: 9
+// Zone Eras: 8
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Hermosillo[]  = {
@@ -7389,7 +7402,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Hermosillo[]  = {
     1680 /*until_time_code (25200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -7:00    -    MST    1927 Jun 10 23:00
+  //             -7:00    -    MST    1927 Jun 10
   {
     NULL /*zone_policy*/,
     "MST" /*format*/,
@@ -7399,7 +7412,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Hermosillo[]  = {
     1927 /*until_year*/,
     6 /*until_month*/,
     10 /*until_day*/,
-    5520 /*until_time_code (82800/15)*/,
+    0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -6:00    -    CST    1930 Nov 15
@@ -7441,27 +7454,14 @@ static const AtcZoneEra kAtcZoneEraAmerica_Hermosillo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -7:00    -    MST    1949 Jan 14
+  //             -7:00    -    MST    1996
   {
     NULL /*zone_policy*/,
     "MST" /*format*/,
     -1680 /*offset_code (-25200/15)*/,
     0 /*offset_remainder (-25200%15)*/,
     0 /*delta_minutes*/,
-    1949 /*until_year*/,
-    1 /*until_month*/,
-    14 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-  //             -8:00    -    PST    1970
-  {
-    NULL /*zone_policy*/,
-    "PST" /*format*/,
-    -1920 /*offset_code (-28800/15)*/,
-    0 /*offset_remainder (-28800%15)*/,
-    0 /*delta_minutes*/,
-    1970 /*until_year*/,
+    1996 /*until_year*/,
     1 /*until_month*/,
     1 /*until_day*/,
     0 /*until_time_code (0/15)*/,
@@ -7502,7 +7502,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Hermosillo  = {
   kAtcZoneNameAmerica_Hermosillo /*name*/,
   0x065d21c4 /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  9 /*num_eras*/,
+  8 /*num_eras*/,
   kAtcZoneEraAmerica_Hermosillo /*eras*/,
   NULL /*target_info*/,
 };
@@ -9158,10 +9158,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_La_Paz[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -9217,10 +9217,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Lima[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    Peru    -05/-04
+  //             -5:00    Peru    %z
   {
     &kAtcAllZonePolicyPeru /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -9335,10 +9335,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    1990 Sep 17
+  //             -3:00    Brazil    %z    1990 Sep 17
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -9348,10 +9348,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1995 Oct 13
+  //             -3:00    -    %z    1995 Oct 13
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -9361,10 +9361,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    1996 Sep  4
+  //             -3:00    Brazil    %z    1996 Sep  4
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -9374,10 +9374,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1999 Sep 30
+  //             -3:00    -    %z    1999 Sep 30
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -9387,10 +9387,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2000 Oct 22
+  //             -3:00    Brazil    %z    2000 Oct 22
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -9400,10 +9400,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2001 Sep 13
+  //             -3:00    -    %z    2001 Sep 13
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -9413,10 +9413,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2002 Oct  1
+  //             -3:00    Brazil    %z    2002 Oct  1
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -9426,10 +9426,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Maceio[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -9609,10 +9609,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Manaus[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03    1988 Sep 12
+  //             -4:00    Brazil    %z    1988 Sep 12
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -9622,10 +9622,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Manaus[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1993 Sep 28
+  //             -4:00    -    %z    1993 Sep 28
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -9635,10 +9635,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Manaus[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03    1994 Sep 22
+  //             -4:00    Brazil    %z    1994 Sep 22
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -9648,10 +9648,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Manaus[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -9847,7 +9847,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Matamoros  = {
 
 //---------------------------------------------------------------------------
 // Zone name: America/Mazatlan
-// Zone Eras: 8
+// Zone Eras: 7
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Mazatlan[]  = {
@@ -9864,7 +9864,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Mazatlan[]  = {
     1680 /*until_time_code (25200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -7:00    -    MST    1927 Jun 10 23:00
+  //             -7:00    -    MST    1927 Jun 10
   {
     NULL /*zone_policy*/,
     "MST" /*format*/,
@@ -9874,7 +9874,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Mazatlan[]  = {
     1927 /*until_year*/,
     6 /*until_month*/,
     10 /*until_day*/,
-    5520 /*until_time_code (82800/15)*/,
+    0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -6:00    -    CST    1930 Nov 15
@@ -9916,25 +9916,12 @@ static const AtcZoneEra kAtcZoneEraAmerica_Mazatlan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -7:00    -    MST    1949 Jan 14
+  //             -7:00    -    MST    1970
   {
     NULL /*zone_policy*/,
     "MST" /*format*/,
     -1680 /*offset_code (-25200/15)*/,
     0 /*offset_remainder (-25200%15)*/,
-    0 /*delta_minutes*/,
-    1949 /*until_year*/,
-    1 /*until_month*/,
-    14 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-  //             -8:00    -    PST    1970
-  {
-    NULL /*zone_policy*/,
-    "PST" /*format*/,
-    -1920 /*offset_code (-28800/15)*/,
-    0 /*offset_remainder (-28800%15)*/,
     0 /*delta_minutes*/,
     1970 /*until_year*/,
     1 /*until_month*/,
@@ -9964,7 +9951,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Mazatlan  = {
   kAtcZoneNameAmerica_Mazatlan /*name*/,
   0x0532189e /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  8 /*num_eras*/,
+  7 /*num_eras*/,
   kAtcZoneEraAmerica_Mazatlan /*eras*/,
   NULL /*target_info*/,
 };
@@ -10073,7 +10060,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Merida[]  = {
     1440 /*until_time_code (21600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -6:00    -    CST    1981 Dec 23
+  //             -6:00    -    CST    1981 Dec 26  2:00
   {
     NULL /*zone_policy*/,
     "CST" /*format*/,
@@ -10082,11 +10069,11 @@ static const AtcZoneEra kAtcZoneEraAmerica_Merida[]  = {
     0 /*delta_minutes*/,
     1981 /*until_year*/,
     12 /*until_month*/,
-    23 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
+    26 /*until_day*/,
+    480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    EST    1982 Dec  2
+  //             -5:00    -    EST    1982 Nov  2  2:00
   {
     NULL /*zone_policy*/,
     "EST" /*format*/,
@@ -10094,9 +10081,9 @@ static const AtcZoneEra kAtcZoneEraAmerica_Merida[]  = {
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
     1982 /*until_year*/,
-    12 /*until_month*/,
+    11 /*until_month*/,
     2 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
+    480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -6:00    Mexico    C%sT
@@ -10295,7 +10282,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Mexico_City[]  = {
     1680 /*until_time_code (25200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -7:00    -    MST    1927 Jun 10 23:00
+  //             -7:00    -    MST    1927 Jun 10
   {
     NULL /*zone_policy*/,
     "MST" /*format*/,
@@ -10305,7 +10292,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Mexico_City[]  = {
     1927 /*until_year*/,
     6 /*until_month*/,
     10 /*until_day*/,
-    5520 /*until_time_code (82800/15)*/,
+    0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -6:00    -    CST    1930 Nov 15
@@ -10419,10 +10406,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Miquelon[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1987
+  //             -3:00    -    %z    1987
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -10432,10 +10419,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Miquelon[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Canada    -03/-02
+  //             -3:00    Canada    %z
   {
     &kAtcAllZonePolicyCanada /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -10598,7 +10585,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Moncton  = {
 
 //---------------------------------------------------------------------------
 // Zone name: America/Monterrey
-// Zone Eras: 4
+// Zone Eras: 7
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Monterrey[]  = {
@@ -10614,6 +10601,45 @@ static const AtcZoneEra kAtcZoneEraAmerica_Monterrey[]  = {
     1 /*until_day*/,
     1440 /*until_time_code (21600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
+  },
+  //             -7:00    -    MST    1927 Jun 10
+  {
+    NULL /*zone_policy*/,
+    "MST" /*format*/,
+    -1680 /*offset_code (-25200/15)*/,
+    0 /*offset_remainder (-25200%15)*/,
+    0 /*delta_minutes*/,
+    1927 /*until_year*/,
+    6 /*until_month*/,
+    10 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -6:00    -    CST    1930 Nov 15
+  {
+    NULL /*zone_policy*/,
+    "CST" /*format*/,
+    -1440 /*offset_code (-21600/15)*/,
+    0 /*offset_remainder (-21600%15)*/,
+    0 /*delta_minutes*/,
+    1930 /*until_year*/,
+    11 /*until_month*/,
+    15 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -7:00    Mexico    M%sT    1932 Apr  1
+  {
+    &kAtcAllZonePolicyMexico /*zone_policy*/,
+    "M%T" /*format*/,
+    -1680 /*offset_code (-25200/15)*/,
+    0 /*offset_remainder (-25200%15)*/,
+    0 /*delta_minutes*/,
+    1932 /*until_year*/,
+    4 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -6:00    -    CST    1988
   {
@@ -10663,7 +10689,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Monterrey  = {
   kAtcZoneNameAmerica_Monterrey /*name*/,
   0x269a1deb /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  4 /*num_eras*/,
+  7 /*num_eras*/,
   kAtcZoneEraAmerica_Monterrey /*eras*/,
   NULL /*target_info*/,
 };
@@ -10700,10 +10726,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Montevideo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1923 Oct  1
+  //             -4:00    -    %z    1923 Oct  1
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -10713,10 +10739,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Montevideo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:30    Uruguay    -0330/-03 1942 Dec 14
+  //             -3:30    Uruguay    %z    1942 Dec 14
   {
     &kAtcAllZonePolicyUruguay /*zone_policy*/,
-    "-0330/-03" /*format*/,
+    "" /*format*/,
     -840 /*offset_code (-12600/15)*/,
     0 /*offset_remainder (-12600%15)*/,
     0 /*delta_minutes*/,
@@ -10726,10 +10752,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Montevideo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Uruguay    -03/-0230 1960
+  //             -3:00    Uruguay    %z    1960
   {
     &kAtcAllZonePolicyUruguay /*zone_policy*/,
-    "-03/-0230" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -10739,10 +10765,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Montevideo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Uruguay    -03/-02    1968
+  //             -3:00    Uruguay    %z    1968
   {
     &kAtcAllZonePolicyUruguay /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -10752,10 +10778,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Montevideo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Uruguay    -03/-0230 1970
+  //             -3:00    Uruguay    %z    1970
   {
     &kAtcAllZonePolicyUruguay /*zone_policy*/,
-    "-03/-0230" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -10765,10 +10791,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Montevideo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Uruguay    -03/-02    1974
+  //             -3:00    Uruguay    %z    1974
   {
     &kAtcAllZonePolicyUruguay /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -10778,10 +10804,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Montevideo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Uruguay    -03/-0130 1974 Mar 10
+  //             -3:00    Uruguay    %z    1974 Mar 10
   {
     &kAtcAllZonePolicyUruguay /*zone_policy*/,
-    "-03/-0130" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -10791,10 +10817,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Montevideo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Uruguay    -03/-0230 1974 Dec 22
+  //             -3:00    Uruguay    %z    1974 Dec 22
   {
     &kAtcAllZonePolicyUruguay /*zone_policy*/,
-    "-03/-0230" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -10804,10 +10830,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Montevideo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Uruguay    -03/-02
+  //             -3:00    Uruguay    %z
   {
     &kAtcAllZonePolicyUruguay /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -11085,10 +11111,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    Brazil    -02/-01    1990 Sep 17
+  //             -2:00    Brazil    %z    1990 Sep 17
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -11098,10 +11124,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    -    -02    1999 Sep 30
+  //             -2:00    -    %z    1999 Sep 30
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -11111,10 +11137,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    Brazil    -02/-01    2000 Oct 15
+  //             -2:00    Brazil    %z    2000 Oct 15
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -11124,10 +11150,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    -    -02    2001 Sep 13
+  //             -2:00    -    %z    2001 Sep 13
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -11137,10 +11163,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    Brazil    -02/-01    2002 Oct  1
+  //             -2:00    Brazil    %z    2002 Oct  1
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -11150,10 +11176,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Noronha[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    -    -02
+  //             -2:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -11373,10 +11399,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Nuuk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1980 Apr  6  2:00
+  //             -3:00    -    %z    1980 Apr  6  2:00
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -11386,10 +11412,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Nuuk[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    EU    -03/-02    2023 Mar 26  1:00u
+  //             -3:00    EU    %z    2023 Mar 26  1:00u
   {
     &kAtcAllZonePolicyEU /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -11399,10 +11425,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Nuuk[]  = {
     240 /*until_time_code (3600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -2:00    -    -02    2023 Oct 29  1:00u
+  //             -2:00    -    %z    2023 Oct 29  1:00u
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -11412,10 +11438,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Nuuk[]  = {
     240 /*until_time_code (3600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -2:00    EU    -02/-01
+  //             -2:00    EU    %z
   {
     &kAtcAllZonePolicyEU /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -11458,7 +11484,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Ojinaga[]  = {
     1680 /*until_time_code (25200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -7:00    -    MST    1927 Jun 10 23:00
+  //             -7:00    -    MST    1927 Jun 10
   {
     NULL /*zone_policy*/,
     "MST" /*format*/,
@@ -11468,7 +11494,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Ojinaga[]  = {
     1927 /*until_year*/,
     6 /*until_month*/,
     10 /*until_day*/,
-    5520 /*until_time_code (82800/15)*/,
+    0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -6:00    -    CST    1930 Nov 15
@@ -11706,10 +11732,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Paramaribo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:30    -    -0330    1984 Oct
+  //             -3:30    -    %z    1984 Oct
   {
     NULL /*zone_policy*/,
-    "-0330" /*format*/,
+    "" /*format*/,
     -840 /*offset_code (-12600/15)*/,
     0 /*offset_remainder (-12600%15)*/,
     0 /*delta_minutes*/,
@@ -11719,10 +11745,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Paramaribo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -11935,10 +11961,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Porto_Velho[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03    1988 Sep 12
+  //             -4:00    Brazil    %z    1988 Sep 12
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -11948,10 +11974,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Porto_Velho[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12079,10 +12105,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05    1916 Jul  1
+  //             -5:00    -    %z    1916 Jul  1
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12105,10 +12131,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1919 Jul  1
+  //             -4:00    -    %z    1919 Jul  1
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12131,10 +12157,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    Chile    -05/-04    1932 Sep  1
+  //             -5:00    Chile    %z    1932 Sep  1
   {
     &kAtcAllZonePolicyChile /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12144,10 +12170,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1942 Jun  1
+  //             -4:00    -    %z    1942 Jun  1
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12157,10 +12183,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05    1942 Aug  1
+  //             -5:00    -    %z    1942 Aug  1
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12170,10 +12196,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1946 Aug 28 24:00
+  //             -4:00    -    %z    1946 Aug 28 24:00
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12183,10 +12209,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    1:00    -04    1947 Mar 31 24:00
+  //             -5:00    1:00    %z    1947 Mar 31 24:00
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     60 /*delta_minutes*/,
@@ -12196,10 +12222,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05    1947 May 21 23:00
+  //             -5:00    -    %z    1947 May 21 23:00
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12209,10 +12235,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     5520 /*until_time_code (82800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Chile    -04/-03    2016 Dec  4
+  //             -4:00    Chile    %z    2016 Dec  4
   {
     &kAtcAllZonePolicyChile /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12222,10 +12248,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Punta_Arenas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -12340,10 +12366,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    1990 Sep 17
+  //             -3:00    Brazil    %z    1990 Sep 17
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -12353,10 +12379,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    1999 Sep 30
+  //             -3:00    -    %z    1999 Sep 30
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -12366,10 +12392,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2000 Oct 15
+  //             -3:00    Brazil    %z    2000 Oct 15
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -12379,10 +12405,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03    2001 Sep 13
+  //             -3:00    -    %z    2001 Sep 13
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -12392,10 +12418,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    2002 Oct  1
+  //             -3:00    Brazil    %z    2002 Oct  1
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -12405,10 +12431,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Recife[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -12608,10 +12634,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Rio_Branco[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    Brazil    -05/-04    1988 Sep 12
+  //             -5:00    Brazil    %z    1988 Sep 12
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12621,10 +12647,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Rio_Branco[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05    2008 Jun 24  0:00
+  //             -5:00    -    %z    2008 Jun 24  0:00
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12634,10 +12660,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Rio_Branco[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2013 Nov 10
+  //             -4:00    -    %z    2013 Nov 10
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12647,10 +12673,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Rio_Branco[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05
+  //             -5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12693,10 +12719,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santarem[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Brazil    -04/-03    1988 Sep 12
+  //             -4:00    Brazil    %z    1988 Sep 12
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12706,10 +12732,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santarem[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    2008 Jun 24  0:00
+  //             -4:00    -    %z    2008 Jun 24  0:00
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12719,10 +12745,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santarem[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -12778,10 +12804,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05    1916 Jul  1
+  //             -5:00    -    %z    1916 Jul  1
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12804,10 +12830,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1919 Jul  1
+  //             -4:00    -    %z    1919 Jul  1
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12830,10 +12856,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    Chile    -05/-04    1932 Sep  1
+  //             -5:00    Chile    %z    1932 Sep  1
   {
     &kAtcAllZonePolicyChile /*zone_policy*/,
-    "-05/-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12843,10 +12869,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1942 Jun  1
+  //             -4:00    -    %z    1942 Jun  1
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12856,10 +12882,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05    1942 Aug  1
+  //             -5:00    -    %z    1942 Aug  1
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12869,10 +12895,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04    1946 Jul 14 24:00
+  //             -4:00    -    %z    1946 Jul 14 24:00
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -12882,10 +12908,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    1:00    -03    1946 Aug 28 24:00
+  //             -4:00    1:00    %z    1946 Aug 28 24:00
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     60 /*delta_minutes*/,
@@ -12895,10 +12921,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    1:00    -04    1947 Mar 31 24:00
+  //             -5:00    1:00    %z    1947 Mar 31 24:00
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     60 /*delta_minutes*/,
@@ -12908,10 +12934,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05    1947 May 21 23:00
+  //             -5:00    -    %z    1947 May 21 23:00
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -12921,10 +12947,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Santiago[]  = {
     5520 /*until_time_code (82800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Chile    -04/-03
+  //             -4:00    Chile    %z
   {
     &kAtcAllZonePolicyChile /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -13065,10 +13091,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Sao_Paulo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02    1963 Oct 23  0:00
+  //             -3:00    Brazil    %z    1963 Oct 23  0:00
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -13078,10 +13104,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Sao_Paulo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    1:00    -02    1964
+  //             -3:00    1:00    %z    1964
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     60 /*delta_minutes*/,
@@ -13091,10 +13117,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Sao_Paulo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Brazil    -03/-02
+  //             -3:00    Brazil    %z
   {
     &kAtcAllZonePolicyBrazil /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -13137,10 +13163,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Scoresbysund[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    -    -02    1980 Apr  6  2:00
+  //             -2:00    -    %z    1980 Apr  6  2:00
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -13150,10 +13176,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Scoresbysund[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    C-Eur    -02/-01    1981 Mar 29
+  //             -2:00    C-Eur    %z    1981 Mar 29
   {
     &kAtcAllZonePolicyC_Eur /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -13163,10 +13189,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Scoresbysund[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -1:00    EU    -01/+00 2024 Mar 31
+  //             -1:00    EU    %z    2024 Mar 31
   {
     &kAtcAllZonePolicyEU /*zone_policy*/,
-    "-01/+00" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -13176,10 +13202,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Scoresbysund[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    EU    -02/-01
+  //             -2:00    EU    %z
   {
     &kAtcAllZonePolicyEU /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -13630,7 +13656,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Thule  = {
 
 //---------------------------------------------------------------------------
 // Zone name: America/Tijuana
-// Zone Eras: 19
+// Zone Eras: 25
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Tijuana[]  = {
@@ -13660,7 +13686,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Tijuana[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -8:00    -    PST    1927 Jun 10 23:00
+  //             -8:00    -    PST    1927 Jun 10
   {
     NULL /*zone_policy*/,
     "PST" /*format*/,
@@ -13670,7 +13696,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Tijuana[]  = {
     1927 /*until_year*/,
     6 /*until_month*/,
     10 /*until_day*/,
-    5520 /*until_time_code (82800/15)*/,
+    0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -7:00    -    MST    1930 Nov 15
@@ -13738,7 +13764,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Tijuana[]  = {
     5520 /*until_time_code (82800/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -8:00    1:00    PPT    1945 Nov 12
+  //             -8:00    1:00    PPT    1945 Nov 15
   {
     NULL /*zone_policy*/,
     "PPT" /*format*/,
@@ -13747,7 +13773,7 @@ static const AtcZoneEra kAtcZoneEraAmerica_Tijuana[]  = {
     60 /*delta_minutes*/,
     1945 /*until_year*/,
     11 /*until_month*/,
-    12 /*until_day*/,
+    15 /*until_day*/,
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
@@ -13775,6 +13801,84 @@ static const AtcZoneEra kAtcZoneEraAmerica_Tijuana[]  = {
     1 /*until_month*/,
     14 /*until_day*/,
     0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -8:00    -    PST    1950 May  1
+  {
+    NULL /*zone_policy*/,
+    "PST" /*format*/,
+    -1920 /*offset_code (-28800/15)*/,
+    0 /*offset_remainder (-28800%15)*/,
+    0 /*delta_minutes*/,
+    1950 /*until_year*/,
+    5 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -8:00    1:00    PDT    1950 Sep 24
+  {
+    NULL /*zone_policy*/,
+    "PDT" /*format*/,
+    -1920 /*offset_code (-28800/15)*/,
+    0 /*offset_remainder (-28800%15)*/,
+    60 /*delta_minutes*/,
+    1950 /*until_year*/,
+    9 /*until_month*/,
+    24 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -8:00    -    PST    1951 Apr 29  2:00
+  {
+    NULL /*zone_policy*/,
+    "PST" /*format*/,
+    -1920 /*offset_code (-28800/15)*/,
+    0 /*offset_remainder (-28800%15)*/,
+    0 /*delta_minutes*/,
+    1951 /*until_year*/,
+    4 /*until_month*/,
+    29 /*until_day*/,
+    480 /*until_time_code (7200/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -8:00    1:00    PDT    1951 Sep 30  2:00
+  {
+    NULL /*zone_policy*/,
+    "PDT" /*format*/,
+    -1920 /*offset_code (-28800/15)*/,
+    0 /*offset_remainder (-28800%15)*/,
+    60 /*delta_minutes*/,
+    1951 /*until_year*/,
+    9 /*until_month*/,
+    30 /*until_day*/,
+    480 /*until_time_code (7200/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -8:00    -    PST    1952 Apr 27  2:00
+  {
+    NULL /*zone_policy*/,
+    "PST" /*format*/,
+    -1920 /*offset_code (-28800/15)*/,
+    0 /*offset_remainder (-28800%15)*/,
+    0 /*delta_minutes*/,
+    1952 /*until_year*/,
+    4 /*until_month*/,
+    27 /*until_day*/,
+    480 /*until_time_code (7200/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -8:00    1:00    PDT    1952 Sep 28  2:00
+  {
+    NULL /*zone_policy*/,
+    "PDT" /*format*/,
+    -1920 /*offset_code (-28800/15)*/,
+    0 /*offset_remainder (-28800%15)*/,
+    60 /*delta_minutes*/,
+    1952 /*until_year*/,
+    9 /*until_month*/,
+    28 /*until_day*/,
+    480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //             -8:00    -    PST    1954
@@ -13890,7 +13994,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Tijuana  = {
   kAtcZoneNameAmerica_Tijuana /*name*/,
   0x6aa1df72 /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  19 /*num_eras*/,
+  25 /*num_eras*/,
   kAtcZoneEraAmerica_Tijuana /*eras*/,
   NULL /*target_info*/,
 };
@@ -14339,10 +14443,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2009 Oct 18  2:00
+  //              8:00    -    %z    2009 Oct 18  2:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -14352,10 +14456,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2010 Mar  5  2:00
+  //             11:00    -    %z    2010 Mar  5  2:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -14365,10 +14469,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2011 Oct 28  2:00
+  //              8:00    -    %z    2011 Oct 28  2:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -14378,10 +14482,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2012 Feb 21 17:00u
+  //             11:00    -    %z    2012 Feb 21 17:00u
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -14391,10 +14495,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     4080 /*until_time_code (61200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //              8:00    -    +08    2016 Oct 22
+  //              8:00    -    %z    2016 Oct 22
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -14404,10 +14508,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2018 Mar 11  4:00
+  //             11:00    -    %z    2018 Mar 11  4:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -14417,10 +14521,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     960 /*until_time_code (14400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2018 Oct  7  4:00
+  //              8:00    -    %z    2018 Oct  7  4:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -14430,10 +14534,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     960 /*until_time_code (14400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2019 Mar 17  3:00
+  //             11:00    -    %z    2019 Mar 17  3:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -14443,10 +14547,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2019 Oct  4  3:00
+  //              8:00    -    %z    2019 Oct  4  3:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -14456,10 +14560,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2020 Mar  8  3:00
+  //             11:00    -    %z    2020 Mar  8  3:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -14469,10 +14573,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2020 Oct  4  0:01
+  //              8:00    -    %z    2020 Oct  4  0:01
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -14482,10 +14586,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     4 /*until_time_code (60/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2021 Mar 14  0:00
+  //             11:00    -    %z    2021 Mar 14  0:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -14495,10 +14599,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2021 Oct  3  0:01
+  //              8:00    -    %z    2021 Oct  3  0:01
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -14508,10 +14612,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     4 /*until_time_code (60/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2022 Mar 13  0:00
+  //             11:00    -    %z    2022 Mar 13  0:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -14521,10 +14625,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    2022 Oct  2  0:01
+  //              8:00    -    %z    2022 Oct  2  0:01
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -14534,10 +14638,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     4 /*until_time_code (60/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    2023 Mar  9  3:00
+  //             11:00    -    %z    2023 Mar  9  3:00
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -14547,10 +14651,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Casey[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08
+  //              8:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -14593,10 +14697,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07    1964 Nov
+  //             7:00    -    %z    1964 Nov
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -14619,10 +14723,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07    2009 Oct 18  2:00
+  //             7:00    -    %z    2009 Oct 18  2:00
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -14632,10 +14736,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    2010 Mar 10 20:00u
+  //             5:00    -    %z    2010 Mar 10 20:00u
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -14645,10 +14749,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
     4800 /*until_time_code (72000/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             7:00    -    +07    2011 Oct 28  2:00
+  //             7:00    -    %z    2011 Oct 28  2:00
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -14658,10 +14762,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    2012 Feb 21 20:00u
+  //             5:00    -    %z    2012 Feb 21 20:00u
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -14671,10 +14775,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Davis[]  = {
     4800 /*until_time_code (72000/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             7:00    -    +07
+  //             7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -14854,10 +14958,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Mawson[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    2009 Oct 18  2:00
+  //             6:00    -    %z    2009 Oct 18  2:00
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -14867,10 +14971,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Mawson[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -14913,10 +15017,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Palmer[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Arg    -04/-03    1969 Oct  5
+  //             -4:00    Arg    %z    1969 Oct  5
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -14926,10 +15030,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Palmer[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Arg    -03/-02    1982 May
+  //             -3:00    Arg    %z    1982 May
   {
     &kAtcAllZonePolicyArg /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -14939,10 +15043,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Palmer[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Chile    -04/-03    2016 Dec  4
+  //             -4:00    Chile    %z    2016 Dec  4
   {
     &kAtcAllZonePolicyChile /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -14952,10 +15056,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Palmer[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -14998,10 +15102,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Rothera[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -15090,10 +15194,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Vostok[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07    1994 Feb
+  //             7:00    -    %z    1994 Feb
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -15116,10 +15220,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Vostok[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07    2023 Dec 18  2:00
+  //             7:00    -    %z    2023 Dec 18  2:00
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -15129,10 +15233,10 @@ static const AtcZoneEra kAtcZoneEraAntarctica_Vostok[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15175,10 +15279,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1930 Jun 21
+  //             5:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15188,10 +15292,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00 RussiaAsia +06/+07    1991 Mar 31  2:00s
+  //             6:00 RussiaAsia %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -15201,10 +15305,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1992 Jan 19  2:00s
+  //             5:00 RussiaAsia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15214,10 +15318,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00 RussiaAsia    +06/+07    2004 Oct 31  2:00s
+  //             6:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -15227,10 +15331,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00    -    +06    2024 Mar  1  0:00
+  //             6:00    -    %z    2024 Mar  1  0:00
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -15240,10 +15344,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Almaty[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15299,10 +15403,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Amman[]  = {
     0 /*until_time_code (0/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -15345,10 +15449,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Anadyr[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             12:00    -    +12    1930 Jun 21
+  //             12:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -15358,10 +15462,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Anadyr[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             13:00    Russia    +13/+14    1982 Apr  1  0:00s
+  //             13:00    Russia    %z    1982 Apr  1  0:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+13/+14" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -15371,10 +15475,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Anadyr[]  = {
     0 /*until_time_code (0/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    Russia    +12/+13    1991 Mar 31  2:00s
+  //             12:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+12/+13" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -15384,10 +15488,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Anadyr[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    1992 Jan 19  2:00s
+  //             11:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -15397,10 +15501,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Anadyr[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    Russia    +12/+13    2010 Mar 28  2:00s
+  //             12:00    Russia    %z    2010 Mar 28  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+12/+13" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -15410,10 +15514,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Anadyr[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    2011 Mar 27  2:00s
+  //             11:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -15423,10 +15527,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Anadyr[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    -    +12
+  //             12:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -15469,10 +15573,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtau[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04    1930 Jun 21
+  //             4:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -15482,10 +15586,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtau[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1981 Oct  1
+  //             5:00    -    %z    1981 Oct  1
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15495,10 +15599,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtau[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    1982 Apr  1
+  //             6:00    -    %z    1982 Apr  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -15508,10 +15612,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtau[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1991 Mar 31  2:00s
+  //             5:00 RussiaAsia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15521,10 +15625,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    1992 Jan 19  2:00s
+  //             4:00 RussiaAsia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -15534,10 +15638,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1994 Sep 25  2:00s
+  //             5:00 RussiaAsia    %z    1994 Sep 25  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15547,10 +15651,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    2004 Oct 31  2:00s
+  //             4:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -15560,10 +15664,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15606,10 +15710,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtobe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04    1930 Jun 21
+  //             4:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -15619,10 +15723,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtobe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1981 Apr  1
+  //             5:00    -    %z    1981 Apr  1
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15632,10 +15736,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtobe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    1:00    +06    1981 Oct  1
+  //             5:00    1:00    %z    1981 Oct  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     60 /*delta_minutes*/,
@@ -15645,10 +15749,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtobe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    1982 Apr  1
+  //             6:00    -    %z    1982 Apr  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -15658,10 +15762,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtobe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1991 Mar 31  2:00s
+  //             5:00 RussiaAsia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15671,10 +15775,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtobe[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    1992 Jan 19  2:00s
+  //             4:00 RussiaAsia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -15684,10 +15788,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtobe[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    2004 Oct 31  2:00s
+  //             5:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15697,10 +15801,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Aqtobe[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15743,10 +15847,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ashgabat[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04    1930 Jun 21
+  //             4:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -15756,10 +15860,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ashgabat[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1991 Mar 31  2:00
+  //             5:00 RussiaAsia    %z    1991 Mar 31  2:00
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15769,10 +15873,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ashgabat[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    1992 Jan 19  2:00
+  //             4:00 RussiaAsia    %z    1992 Jan 19  2:00
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -15782,10 +15886,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ashgabat[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15828,10 +15932,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03    1930 Jun 21
+  //             3:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -15841,10 +15945,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1981 Oct  1
+  //             5:00    -    %z    1981 Oct  1
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15854,10 +15958,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    1982 Apr  1
+  //             6:00    -    %z    1982 Apr  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -15867,10 +15971,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1991 Mar 31  2:00s
+  //             5:00 RussiaAsia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15880,10 +15984,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    1992 Jan 19  2:00s
+  //             4:00 RussiaAsia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -15893,10 +15997,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1999 Mar 28  2:00s
+  //             5:00 RussiaAsia    %z    1999 Mar 28  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15906,10 +16010,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    2004 Oct 31  2:00s
+  //             4:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -15919,10 +16023,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Atyrau[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -15978,10 +16082,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Baghdad[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03    1982 May
+  //             3:00    -    %z    1982 May
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -15991,10 +16095,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Baghdad[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    Iraq    +03/+04
+  //             3:00    Iraq    %z
   {
     &kAtcAllZonePolicyIraq /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -16037,10 +16141,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Baku[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03    1957 Mar
+  //             3:00    -    %z    1957 Mar
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -16050,10 +16154,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Baku[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00 RussiaAsia +04/+05    1991 Mar 31  2:00s
+  //             4:00 RussiaAsia %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -16063,10 +16167,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Baku[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             3:00 RussiaAsia    +03/+04    1992 Sep lastSun  2:00s
+  //             3:00 RussiaAsia    %z    1992 Sep lastSun  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -16076,10 +16180,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Baku[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00    -    +04    1996
+  //             4:00    -    %z    1996
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -16089,10 +16193,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Baku[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    EUAsia    +04/+05    1997
+  //             4:00    EUAsia    %z    1997
   {
     &kAtcAllZonePolicyEUAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -16102,10 +16206,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Baku[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    Azer    +04/+05
+  //             4:00    Azer    %z
   {
     &kAtcAllZonePolicyAzer /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -16161,10 +16265,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Bangkok[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07
+  //             7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -16207,10 +16311,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              6:00    -    +06    1930 Jun 21
+  //              6:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -16220,10 +16324,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    1991 Mar 31  2:00s
+  //              7:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -16233,10 +16337,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    1992 Jan 19  2:00s
+  //              6:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -16246,10 +16350,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    1995 May 28
+  //              7:00    Russia    %z    1995 May 28
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -16259,10 +16363,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    2011 Mar 27  2:00s
+  //              6:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -16272,10 +16376,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07    2014 Oct 26  2:00s
+  //              7:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -16285,10 +16389,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    -    +06    2016 Mar 27  2:00s
+  //              6:00    -    %z    2016 Mar 27  2:00s
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -16298,10 +16402,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Barnaul[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07
+  //              7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -16390,10 +16494,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Bishkek[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1930 Jun 21
+  //             5:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -16403,10 +16507,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Bishkek[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00 RussiaAsia +06/+07    1991 Mar 31  2:00s
+  //             6:00 RussiaAsia %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -16416,10 +16520,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Bishkek[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1991 Aug 31  2:00
+  //             5:00 RussiaAsia    %z    1991 Aug 31  2:00
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -16429,10 +16533,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Bishkek[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    Kyrgyz    +05/+06    2005 Aug 12
+  //             5:00    Kyrgyz    %z    2005 Aug 12
   {
     &kAtcAllZonePolicyKyrgyz /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -16442,10 +16546,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Bishkek[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06
+  //             6:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -16488,10 +16592,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    1930 Jun 21
+  //              8:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -16501,10 +16605,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    Russia    +09/+10    1991 Mar 31  2:00s
+  //              9:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -16514,10 +16618,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              8:00    Russia    +08/+09    1992 Jan 19  2:00s
+  //              8:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+08/+09" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -16527,10 +16631,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              9:00    Russia    +09/+10    2011 Mar 27  2:00s
+  //              9:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -16540,10 +16644,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10    2014 Oct 26  2:00s
+  //             10:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -16553,10 +16657,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              8:00    -    +08    2016 Mar 27  2:00
+  //              8:00    -    %z    2016 Mar 27  2:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -16566,10 +16670,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Chita[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    -    +09
+  //              9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -16590,91 +16694,6 @@ const AtcZoneInfo kAtcAllZoneAsia_Chita  = {
   &kAtcAllZoneContext /*zone_context*/,
   8 /*num_eras*/,
   kAtcZoneEraAsia_Chita /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: Asia/Choibalsan
-// Zone Eras: 5
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraAsia_Choibalsan[]  = {
-  // 7:38:00 - LMT 1905 Aug
-  {
-    NULL /*zone_policy*/,
-    "LMT" /*format*/,
-    1832 /*offset_code (27480/15)*/,
-    0 /*offset_remainder (27480%15)*/,
-    0 /*delta_minutes*/,
-    1905 /*until_year*/,
-    8 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-  //             7:00    -    +07    1978
-  {
-    NULL /*zone_policy*/,
-    "+07" /*format*/,
-    1680 /*offset_code (25200/15)*/,
-    0 /*offset_remainder (25200%15)*/,
-    0 /*delta_minutes*/,
-    1978 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-  //             8:00    -    +08    1983 Apr
-  {
-    NULL /*zone_policy*/,
-    "+08" /*format*/,
-    1920 /*offset_code (28800/15)*/,
-    0 /*offset_remainder (28800%15)*/,
-    0 /*delta_minutes*/,
-    1983 /*until_year*/,
-    4 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-  //             9:00    Mongol    +09/+10    2008 Mar 31
-  {
-    &kAtcAllZonePolicyMongol /*zone_policy*/,
-    "+09/+10" /*format*/,
-    2160 /*offset_code (32400/15)*/,
-    0 /*offset_remainder (32400%15)*/,
-    0 /*delta_minutes*/,
-    2008 /*until_year*/,
-    3 /*until_month*/,
-    31 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-  //             8:00    Mongol    +08/+09
-  {
-    &kAtcAllZonePolicyMongol /*zone_policy*/,
-    "+08/+09" /*format*/,
-    1920 /*offset_code (28800/15)*/,
-    0 /*offset_remainder (28800%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameAsia_Choibalsan[]  = "Asia/Choibalsan";
-
-const AtcZoneInfo kAtcAllZoneAsia_Choibalsan  = {
-  kAtcZoneNameAsia_Choibalsan /*name*/,
-  0x928aa4a6 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  5 /*num_eras*/,
-  kAtcZoneEraAsia_Choibalsan /*eras*/,
   NULL /*target_info*/,
 };
 
@@ -16710,10 +16729,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Colombo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    -    +0530    1942 Jan  5
+  //             5:30    -    %z    1942 Jan  5
   {
     NULL /*zone_policy*/,
-    "+0530" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     0 /*delta_minutes*/,
@@ -16723,10 +16742,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Colombo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    0:30    +06    1942 Sep
+  //             5:30    0:30    %z    1942 Sep
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     30 /*delta_minutes*/,
@@ -16736,10 +16755,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Colombo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    1:00    +0630    1945 Oct 16  2:00
+  //             5:30    1:00    %z    1945 Oct 16  2:00
   {
     NULL /*zone_policy*/,
-    "+0630" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     60 /*delta_minutes*/,
@@ -16749,10 +16768,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Colombo[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    -    +0530    1996 May 25  0:00
+  //             5:30    -    %z    1996 May 25  0:00
   {
     NULL /*zone_policy*/,
-    "+0530" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     0 /*delta_minutes*/,
@@ -16762,10 +16781,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Colombo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:30    -    +0630    1996 Oct 26  0:30
+  //             6:30    -    %z    1996 Oct 26  0:30
   {
     NULL /*zone_policy*/,
-    "+0630" /*format*/,
+    "" /*format*/,
     1560 /*offset_code (23400/15)*/,
     0 /*offset_remainder (23400%15)*/,
     0 /*delta_minutes*/,
@@ -16775,10 +16794,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Colombo[]  = {
     120 /*until_time_code (1800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    2006 Apr 15  0:30
+  //             6:00    -    %z    2006 Apr 15  0:30
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -16788,10 +16807,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Colombo[]  = {
     120 /*until_time_code (1800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    -    +0530
+  //             5:30    -    %z
   {
     NULL /*zone_policy*/,
-    "+0530" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     0 /*delta_minutes*/,
@@ -16847,10 +16866,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Damascus[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -16906,10 +16925,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dhaka[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:30    -    +0630    1942 May 15
+  //             6:30    -    %z    1942 May 15
   {
     NULL /*zone_policy*/,
-    "+0630" /*format*/,
+    "" /*format*/,
     1560 /*offset_code (23400/15)*/,
     0 /*offset_remainder (23400%15)*/,
     0 /*delta_minutes*/,
@@ -16919,10 +16938,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dhaka[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    -    +0530    1942 Sep
+  //             5:30    -    %z    1942 Sep
   {
     NULL /*zone_policy*/,
-    "+0530" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     0 /*delta_minutes*/,
@@ -16932,10 +16951,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dhaka[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:30    -    +0630    1951 Sep 30
+  //             6:30    -    %z    1951 Sep 30
   {
     NULL /*zone_policy*/,
-    "+0630" /*format*/,
+    "" /*format*/,
     1560 /*offset_code (23400/15)*/,
     0 /*offset_remainder (23400%15)*/,
     0 /*delta_minutes*/,
@@ -16945,10 +16964,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dhaka[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    2009
+  //             6:00    -    %z    2009
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -16958,10 +16977,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dhaka[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    Dhaka    +06/+07
+  //             6:00    Dhaka    %z
   {
     &kAtcAllZonePolicyDhaka /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -16991,23 +17010,23 @@ const AtcZoneInfo kAtcAllZoneAsia_Dhaka  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAsia_Dili[]  = {
-  // 8:22:20 - LMT 1912 Jan 1
+  // 8:22:20 - LMT 1911 Dec 31 16:00u
   {
     NULL /*zone_policy*/,
     "LMT" /*format*/,
     2009 /*offset_code (30140/15)*/,
     5 /*offset_remainder (30140%15)*/,
     0 /*delta_minutes*/,
-    1912 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+    1911 /*until_year*/,
+    12 /*until_month*/,
+    31 /*until_day*/,
+    3840 /*until_time_code (57600/15)*/,
+    32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             8:00    -    +08    1942 Feb 21 23:00
+  //             8:00    -    %z    1942 Feb 21 23:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -17017,10 +17036,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dili[]  = {
     5520 /*until_time_code (82800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09    1976 May  3
+  //             9:00    -    %z    1976 May  3
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -17030,10 +17049,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dili[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00    -    +08    2000 Sep 17  0:00
+  //             8:00    -    %z    2000 Sep 17  0:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -17043,10 +17062,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dili[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09
+  //             9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -17089,10 +17108,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dubai[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04
+  //             4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -17135,10 +17154,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dushanbe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1930 Jun 21
+  //             5:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -17148,10 +17167,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dushanbe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00 RussiaAsia +06/+07    1991 Mar 31  2:00s
+  //             6:00 RussiaAsia %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -17161,10 +17180,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dushanbe[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00    1:00    +06    1991 Sep  9  2:00s
+  //             5:00    1:00    %z    1991 Sep  9  2:00s
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     60 /*delta_minutes*/,
@@ -17174,10 +17193,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Dushanbe[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -17246,10 +17265,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Famagusta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03    2017 Oct 29 1:00u
+  //             3:00    -    %z    2017 Oct 29 1:00u
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -17592,10 +17611,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07    1942 Dec 31 23:00
+  //             7:00    -    %z    1942 Dec 31 23:00
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -17605,10 +17624,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     5520 /*until_time_code (82800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00    -    +08    1945 Mar 14 23:00
+  //             8:00    -    %z    1945 Mar 14 23:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -17618,10 +17637,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     5520 /*until_time_code (82800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09    1945 Sep  1 24:00
+  //             9:00    -    %z    1945 Sep  1 24:00
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -17631,10 +17650,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07    1947 Apr  1
+  //             7:00    -    %z    1947 Apr  1
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -17644,10 +17663,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00    -    +08    1955 Jul  1 01:00
+  //             8:00    -    %z    1955 Jul  1 01:00
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -17657,10 +17676,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     240 /*until_time_code (3600/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07    1959 Dec 31 23:00
+  //             7:00    -    %z    1959 Dec 31 23:00
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -17670,10 +17689,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     5520 /*until_time_code (82800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00    -    +08    1975 Jun 13
+  //             8:00    -    %z    1975 Jun 13
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -17683,10 +17702,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ho_Chi_Minh[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07
+  //             7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -17827,10 +17846,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Hovd[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    1978
+  //             6:00    -    %z    1978
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -17840,10 +17859,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Hovd[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    Mongol    +07/+08
+  //             7:00    Mongol    %z
   {
     &kAtcAllZonePolicyMongol /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -17899,10 +17918,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Irkutsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              7:00    -    +07    1930 Jun 21
+  //              7:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -17912,10 +17931,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Irkutsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    Russia    +08/+09    1991 Mar 31  2:00s
+  //              8:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+08/+09" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -17925,10 +17944,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Irkutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    1992 Jan 19  2:00s
+  //              7:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -17938,10 +17957,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Irkutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              8:00    Russia    +08/+09    2011 Mar 27  2:00s
+  //              8:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+08/+09" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -17951,10 +17970,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Irkutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              9:00    -    +09    2014 Oct 26  2:00s
+  //              9:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -17964,10 +17983,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Irkutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              8:00    -    +08
+  //              8:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -18023,10 +18042,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Jakarta[]  = {
     4000 /*until_time_code (60000/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             7:20    -    +0720    1932 Nov
+  //             7:20    -    %z    1932 Nov
   {
     NULL /*zone_policy*/,
-    "+0720" /*format*/,
+    "" /*format*/,
     1760 /*offset_code (26400/15)*/,
     0 /*offset_remainder (26400%15)*/,
     0 /*delta_minutes*/,
@@ -18036,10 +18055,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Jakarta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:30    -    +0730    1942 Mar 23
+  //             7:30    -    %z    1942 Mar 23
   {
     NULL /*zone_policy*/,
-    "+0730" /*format*/,
+    "" /*format*/,
     1800 /*offset_code (27000/15)*/,
     0 /*offset_remainder (27000%15)*/,
     0 /*delta_minutes*/,
@@ -18049,10 +18068,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Jakarta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09    1945 Sep 23
+  //             9:00    -    %z    1945 Sep 23
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -18062,10 +18081,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Jakarta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:30    -    +0730    1948 May
+  //             7:30    -    %z    1948 May
   {
     NULL /*zone_policy*/,
-    "+0730" /*format*/,
+    "" /*format*/,
     1800 /*offset_code (27000/15)*/,
     0 /*offset_remainder (27000%15)*/,
     0 /*delta_minutes*/,
@@ -18075,10 +18094,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Jakarta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00    -    +08    1950 May
+  //             8:00    -    %z    1950 May
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -18088,10 +18107,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Jakarta[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:30    -    +0730    1964
+  //             7:30    -    %z    1964
   {
     NULL /*zone_policy*/,
-    "+0730" /*format*/,
+    "" /*format*/,
     1800 /*offset_code (27000/15)*/,
     0 /*offset_remainder (27000%15)*/,
     0 /*delta_minutes*/,
@@ -18147,10 +18166,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Jayapura[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09    1944 Sep  1
+  //             9:00    -    %z    1944 Sep  1
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -18160,10 +18179,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Jayapura[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:30    -    +0930    1964
+  //             9:30    -    %z    1964
   {
     NULL /*zone_policy*/,
-    "+0930" /*format*/,
+    "" /*format*/,
     2280 /*offset_code (34200/15)*/,
     0 /*offset_remainder (34200%15)*/,
     0 /*delta_minutes*/,
@@ -18278,10 +18297,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kabul[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04    1945
+  //             4:00    -    %z    1945
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -18291,10 +18310,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kabul[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:30    -    +0430
+  //             4:30    -    %z
   {
     NULL /*zone_policy*/,
-    "+0430" /*format*/,
+    "" /*format*/,
     1080 /*offset_code (16200/15)*/,
     0 /*offset_remainder (16200%15)*/,
     0 /*delta_minutes*/,
@@ -18337,10 +18356,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kamchatka[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11    1930 Jun 21
+  //             11:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -18350,10 +18369,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kamchatka[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             12:00    Russia    +12/+13    1991 Mar 31  2:00s
+  //             12:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+12/+13" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -18363,10 +18382,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kamchatka[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    1992 Jan 19  2:00s
+  //             11:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -18376,10 +18395,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kamchatka[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    Russia    +12/+13    2010 Mar 28  2:00s
+  //             12:00    Russia    %z    2010 Mar 28  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+12/+13" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -18389,10 +18408,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kamchatka[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    2011 Mar 27  2:00s
+  //             11:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -18402,10 +18421,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kamchatka[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    -    +12
+  //             12:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -18448,10 +18467,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Karachi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    -    +0530    1942 Sep
+  //             5:30    -    %z    1942 Sep
   {
     NULL /*zone_policy*/,
-    "+0530" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     0 /*delta_minutes*/,
@@ -18461,10 +18480,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Karachi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    1:00    +0630    1945 Oct 15
+  //             5:30    1:00    %z    1945 Oct 15
   {
     NULL /*zone_policy*/,
-    "+0630" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     60 /*delta_minutes*/,
@@ -18474,10 +18493,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Karachi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    -    +0530    1951 Sep 30
+  //             5:30    -    %z    1951 Sep 30
   {
     NULL /*zone_policy*/,
-    "+0530" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     0 /*delta_minutes*/,
@@ -18487,10 +18506,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Karachi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1971 Mar 26
+  //             5:00    -    %z    1971 Mar 26
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -18546,10 +18565,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kathmandu[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    -    +0530    1986
+  //             5:30    -    %z    1986
   {
     NULL /*zone_policy*/,
-    "+0530" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     0 /*delta_minutes*/,
@@ -18559,10 +18578,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kathmandu[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:45    -    +0545
+  //             5:45    -    %z
   {
     NULL /*zone_policy*/,
-    "+0545" /*format*/,
+    "" /*format*/,
     1380 /*offset_code (20700/15)*/,
     0 /*offset_remainder (20700%15)*/,
     0 /*delta_minutes*/,
@@ -18605,10 +18624,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    1930 Jun 21
+  //              8:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -18618,10 +18637,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    Russia    +09/+10    1991 Mar 31  2:00s
+  //              9:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -18631,10 +18650,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              8:00    Russia    +08/+09    1992 Jan 19  2:00s
+  //              8:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+08/+09" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -18644,10 +18663,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              9:00    Russia    +09/+10    2004
+  //              9:00    Russia    %z    2004
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -18657,10 +18676,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             10:00    Russia    +10/+11    2011 Mar 27  2:00s
+  //             10:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -18670,10 +18689,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11    2011 Sep 13  0:00s
+  //             11:00    -    %z    2011 Sep 13  0:00s
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -18683,10 +18702,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     0 /*until_time_code (0/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10    2014 Oct 26  2:00s
+  //             10:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -18696,10 +18715,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Khandyga[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              9:00    -    +09
+  //              9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -18781,10 +18800,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kolkata[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    1:00    +0630    1942 May 15
+  //             5:30    1:00    %z    1942 May 15
   {
     NULL /*zone_policy*/,
-    "+0630" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     60 /*delta_minutes*/,
@@ -18807,10 +18826,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kolkata[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    1:00    +0630    1945 Oct 15
+  //             5:30    1:00    %z    1945 Oct 15
   {
     NULL /*zone_policy*/,
-    "+0630" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     60 /*delta_minutes*/,
@@ -18866,10 +18885,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Krasnoyarsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              6:00    -    +06    1930 Jun 21
+  //              6:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -18879,10 +18898,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Krasnoyarsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    1991 Mar 31  2:00s
+  //              7:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -18892,10 +18911,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Krasnoyarsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    1992 Jan 19  2:00s
+  //              6:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -18905,10 +18924,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Krasnoyarsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    2011 Mar 27  2:00s
+  //              7:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -18918,10 +18937,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Krasnoyarsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              8:00    -    +08    2014 Oct 26  2:00s
+  //              8:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -18931,10 +18950,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Krasnoyarsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07
+  //              7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -18977,10 +18996,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kuching[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:30    -    +0730    1933
+  //             7:30    -    %z    1933
   {
     NULL /*zone_policy*/,
-    "+0730" /*format*/,
+    "" /*format*/,
     1800 /*offset_code (27000/15)*/,
     0 /*offset_remainder (27000%15)*/,
     0 /*delta_minutes*/,
@@ -18990,10 +19009,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kuching[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00 NBorneo  +08/+0820    1942 Feb 16
+  //             8:00 NBorneo    %z    1942 Feb 16
   {
     &kAtcAllZonePolicyNBorneo /*zone_policy*/,
-    "+08/+0820" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -19003,10 +19022,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kuching[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09    1945 Sep 12
+  //             9:00    -    %z    1945 Sep 12
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -19016,10 +19035,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Kuching[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00    -    +08
+  //             8:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -19075,10 +19094,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Macau[]  = {
     5520 /*until_time_code (82800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    Macau    +09/+10    1945 Sep 30 24:00
+  //             9:00    Macau    %z    1945 Sep 30 24:00
   {
     &kAtcAllZonePolicyMacau /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -19134,10 +19153,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             10:00    -    +10    1930 Jun 21
+  //             10:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -19147,10 +19166,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    1991 Mar 31  2:00s
+  //             11:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -19160,10 +19179,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    Russia    +10/+11    1992 Jan 19  2:00s
+  //             10:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -19173,10 +19192,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    2011 Mar 27  2:00s
+  //             11:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -19186,10 +19205,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    -    +12    2014 Oct 26  2:00s
+  //             12:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -19199,10 +19218,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10    2016 Apr 24  2:00s
+  //             10:00    -    %z    2016 Apr 24  2:00s
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -19212,10 +19231,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Magadan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -19271,10 +19290,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Makassar[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00    -    +08    1942 Feb  9
+  //             8:00    -    %z    1942 Feb  9
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -19284,10 +19303,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Makassar[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09    1945 Sep 23
+  //             9:00    -    %z    1945 Sep 23
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -19487,10 +19506,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novokuznetsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              6:00    -    +06    1930 Jun 21
+  //              6:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19500,10 +19519,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novokuznetsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    1991 Mar 31  2:00s
+  //              7:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -19513,10 +19532,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novokuznetsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    1992 Jan 19  2:00s
+  //              6:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19526,10 +19545,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novokuznetsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    2010 Mar 28  2:00s
+  //              7:00    Russia    %z    2010 Mar 28  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -19539,10 +19558,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novokuznetsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    2011 Mar 27  2:00s
+  //              6:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19552,10 +19571,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novokuznetsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07
+  //              7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -19598,10 +19617,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     1440 /*until_time_code (21600/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              6:00    -    +06    1930 Jun 21
+  //              6:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19611,10 +19630,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    1991 Mar 31  2:00s
+  //              7:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -19624,10 +19643,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    1992 Jan 19  2:00s
+  //              6:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19637,10 +19656,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    1993 May 23
+  //              7:00    Russia    %z    1993 May 23
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -19650,10 +19669,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    2011 Mar 27  2:00s
+  //              6:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19663,10 +19682,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07    2014 Oct 26  2:00s
+  //              7:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -19676,10 +19695,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    -    +06    2016 Jul 24  2:00s
+  //              6:00    -    %z    2016 Jul 24  2:00s
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19689,10 +19708,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Novosibirsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07
+  //              7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -19735,10 +19754,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Omsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              5:00    -    +05    1930 Jun 21
+  //              5:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -19748,10 +19767,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Omsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    1991 Mar 31  2:00s
+  //              6:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19761,10 +19780,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Omsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              5:00    Russia    +05/+06    1992 Jan 19  2:00s
+  //              5:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -19774,10 +19793,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Omsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    2011 Mar 27  2:00s
+  //              6:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19787,10 +19806,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Omsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07    2014 Oct 26  2:00s
+  //              7:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -19800,10 +19819,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Omsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    -    +06
+  //              6:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19846,10 +19865,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03    1930 Jun 21
+  //             3:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -19859,10 +19878,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1981 Apr  1
+  //             5:00    -    %z    1981 Apr  1
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -19872,10 +19891,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    1:00    +06    1981 Oct  1
+  //             5:00    1:00    %z    1981 Oct  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     60 /*delta_minutes*/,
@@ -19885,10 +19904,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    1982 Apr  1
+  //             6:00    -    %z    1982 Apr  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -19898,10 +19917,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1989 Mar 26  2:00s
+  //             5:00 RussiaAsia    %z    1989 Mar 26  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -19911,10 +19930,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    1992 Jan 19  2:00s
+  //             4:00 RussiaAsia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -19924,10 +19943,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1992 Mar 29  2:00s
+  //             5:00 RussiaAsia    %z    1992 Mar 29  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -19937,10 +19956,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    2004 Oct 31  2:00s
+  //             4:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -19950,10 +19969,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Oral[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20009,10 +20028,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Pontianak[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:30    -    +0730    1942 Jan 29
+  //             7:30    -    %z    1942 Jan 29
   {
     NULL /*zone_policy*/,
-    "+0730" /*format*/,
+    "" /*format*/,
     1800 /*offset_code (27000/15)*/,
     0 /*offset_remainder (27000%15)*/,
     0 /*delta_minutes*/,
@@ -20022,10 +20041,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Pontianak[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09    1945 Sep 23
+  //             9:00    -    %z    1945 Sep 23
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -20035,10 +20054,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Pontianak[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:30    -    +0730    1948 May
+  //             7:30    -    %z    1948 May
   {
     NULL /*zone_policy*/,
-    "+0730" /*format*/,
+    "" /*format*/,
     1800 /*offset_code (27000/15)*/,
     0 /*offset_remainder (27000%15)*/,
     0 /*delta_minutes*/,
@@ -20048,10 +20067,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Pontianak[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00    -    +08    1950 May
+  //             8:00    -    %z    1950 May
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -20061,10 +20080,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Pontianak[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:30    -    +0730    1964
+  //             7:30    -    %z    1964
   {
     NULL /*zone_policy*/,
-    "+0730" /*format*/,
+    "" /*format*/,
     1800 /*offset_code (27000/15)*/,
     0 /*offset_remainder (27000%15)*/,
     0 /*delta_minutes*/,
@@ -20231,10 +20250,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qatar[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04    1972 Jun
+  //             4:00    -    %z    1972 Jun
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -20244,10 +20263,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qatar[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -20290,10 +20309,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04    1930 Jun 21
+  //             4:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -20303,10 +20322,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1981 Apr  1
+  //             5:00    -    %z    1981 Apr  1
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20316,10 +20335,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    1:00    +06    1981 Oct  1
+  //             5:00    1:00    %z    1981 Oct  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     60 /*delta_minutes*/,
@@ -20329,10 +20348,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    1982 Apr  1
+  //             6:00    -    %z    1982 Apr  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -20342,10 +20361,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1991 Mar 31  2:00s
+  //             5:00 RussiaAsia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20355,10 +20374,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    1992 Jan 19  2:00s
+  //             4:00 RussiaAsia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -20368,10 +20387,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    2004 Oct 31  2:00s
+  //             5:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20381,10 +20400,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00    -    +06    2024 Mar  1  0:00
+  //             6:00    -    %z    2024 Mar  1  0:00
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -20394,10 +20413,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qostanay[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20440,10 +20459,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04    1930 Jun 21
+  //             4:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -20453,10 +20472,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1981 Apr  1
+  //             5:00    -    %z    1981 Apr  1
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20466,10 +20485,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    1:00    +06    1981 Oct  1
+  //             5:00    1:00    %z    1981 Oct  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     60 /*delta_minutes*/,
@@ -20479,10 +20498,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    1982 Apr  1
+  //             6:00    -    %z    1982 Apr  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -20492,10 +20511,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1991 Mar 31  2:00s
+  //             5:00 RussiaAsia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20505,10 +20524,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    1991 Sep 29  2:00s
+  //             4:00 RussiaAsia    %z    1991 Sep 29  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -20518,10 +20537,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1992 Jan 19  2:00s
+  //             5:00 RussiaAsia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20531,10 +20550,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00 RussiaAsia    +06/+07    1992 Mar 29  2:00s
+  //             6:00 RussiaAsia    %z    1992 Mar 29  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -20544,10 +20563,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    2004 Oct 31  2:00s
+  //             5:00 RussiaAsia    %z    2004 Oct 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20557,10 +20576,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             6:00    -    +06    2018 Dec 21  0:00
+  //             6:00    -    %z    2018 Dec 21  0:00
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -20570,10 +20589,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Qyzylorda[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20616,10 +20635,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Riyadh[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -20662,10 +20681,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    -    +09    1945 Aug 25
+  //              9:00    -    %z    1945 Aug 25
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -20675,10 +20694,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    1991 Mar 31  2:00s
+  //             11:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -20688,10 +20707,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    Russia    +10/+11    1992 Jan 19  2:00s
+  //             10:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -20701,10 +20720,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    1997 Mar lastSun  2:00s
+  //             11:00    Russia    %z    1997 Mar lastSun  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -20714,10 +20733,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    Russia    +10/+11    2011 Mar 27  2:00s
+  //             10:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -20727,10 +20746,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11    2014 Oct 26  2:00s
+  //             11:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -20740,10 +20759,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10    2016 Mar 27  2:00s
+  //             10:00    -    %z    2016 Mar 27  2:00s
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -20753,10 +20772,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Sakhalin[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -20799,10 +20818,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Samarkand[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04    1930 Jun 21
+  //             4:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -20812,10 +20831,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Samarkand[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1981 Apr  1
+  //             5:00    -    %z    1981 Apr  1
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20825,10 +20844,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Samarkand[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    1:00    +06    1981 Oct  1
+  //             5:00    1:00    %z    1981 Oct  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     60 /*delta_minutes*/,
@@ -20838,10 +20857,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Samarkand[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06    1982 Apr  1
+  //             6:00    -    %z    1982 Apr  1
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -20851,10 +20870,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Samarkand[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1992
+  //             5:00 RussiaAsia    %z    1992
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -20864,10 +20883,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Samarkand[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -21080,10 +21099,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Singapore[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07    1933 Jan  1
+  //             7:00    -    %z    1933 Jan  1
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -21093,10 +21112,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Singapore[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    0:20    +0720    1936 Jan  1
+  //             7:00    0:20    %z    1936 Jan  1
   {
     NULL /*zone_policy*/,
-    "+0720" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     20 /*delta_minutes*/,
@@ -21106,10 +21125,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Singapore[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:20    -    +0720    1941 Sep  1
+  //             7:20    -    %z    1941 Sep  1
   {
     NULL /*zone_policy*/,
-    "+0720" /*format*/,
+    "" /*format*/,
     1760 /*offset_code (26400/15)*/,
     0 /*offset_remainder (26400%15)*/,
     0 /*delta_minutes*/,
@@ -21119,10 +21138,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Singapore[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:30    -    +0730    1942 Feb 16
+  //             7:30    -    %z    1942 Feb 16
   {
     NULL /*zone_policy*/,
-    "+0730" /*format*/,
+    "" /*format*/,
     1800 /*offset_code (27000/15)*/,
     0 /*offset_remainder (27000%15)*/,
     0 /*delta_minutes*/,
@@ -21132,10 +21151,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Singapore[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09    1945 Sep 12
+  //             9:00    -    %z    1945 Sep 12
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -21145,10 +21164,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Singapore[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:30    -    +0730    1981 Dec 31 16:00u
+  //             7:30    -    %z    1981 Dec 31 16:00u
   {
     NULL /*zone_policy*/,
-    "+0730" /*format*/,
+    "" /*format*/,
     1800 /*offset_code (27000/15)*/,
     0 /*offset_remainder (27000%15)*/,
     0 /*delta_minutes*/,
@@ -21158,10 +21177,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Singapore[]  = {
     3840 /*until_time_code (57600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             8:00    -    +08
+  //             8:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -21204,10 +21223,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Srednekolymsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             10:00    -    +10    1930 Jun 21
+  //             10:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -21217,10 +21236,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Srednekolymsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    1991 Mar 31  2:00s
+  //             11:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -21230,10 +21249,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Srednekolymsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    Russia    +10/+11    1992 Jan 19  2:00s
+  //             10:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -21243,10 +21262,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Srednekolymsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    2011 Mar 27  2:00s
+  //             11:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -21256,10 +21275,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Srednekolymsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    -    +12    2014 Oct 26  2:00s
+  //             12:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -21269,10 +21288,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Srednekolymsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -21387,10 +21406,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tashkent[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1930 Jun 21
+  //             5:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -21400,10 +21419,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tashkent[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00 RussiaAsia    +06/+07    1991 Mar 31  2:00
+  //             6:00 RussiaAsia    %z    1991 Mar 31  2:00
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -21413,10 +21432,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tashkent[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00 RussiaAsia    +05/+06    1992
+  //             5:00 RussiaAsia    %z    1992
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -21426,10 +21445,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tashkent[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -21485,10 +21504,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03    1957 Mar
+  //             3:00    -    %z    1957 Mar
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -21498,10 +21517,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00 RussiaAsia +04/+05    1991 Mar 31  2:00s
+  //             4:00 RussiaAsia %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -21511,10 +21530,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             3:00 RussiaAsia +03/+04    1992
+  //             3:00 RussiaAsia %z    1992
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -21524,10 +21543,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00 E-EurAsia    +03/+04    1994 Sep lastSun
+  //             3:00 E-EurAsia    %z    1994 Sep lastSun
   {
     &kAtcAllZonePolicyE_EurAsia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -21537,10 +21556,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00 E-EurAsia    +04/+05    1996 Oct lastSun
+  //             4:00 E-EurAsia    %z    1996 Oct lastSun
   {
     &kAtcAllZonePolicyE_EurAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -21550,10 +21569,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    1:00    +05    1997 Mar lastSun
+  //             4:00    1:00    %z    1997 Mar lastSun
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     60 /*delta_minutes*/,
@@ -21563,10 +21582,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00 E-EurAsia    +04/+05    2004 Jun 27
+  //             4:00 E-EurAsia    %z    2004 Jun 27
   {
     &kAtcAllZonePolicyE_EurAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -21576,10 +21595,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00 RussiaAsia    +03/+04    2005 Mar lastSun  2:00
+  //             3:00 RussiaAsia    %z    2005 Mar lastSun  2:00
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -21589,10 +21608,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tbilisi[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    -    +04
+  //             4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -21648,10 +21667,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tehran[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:30    Iran    +0330/+0430 1977 Oct 20 24:00
+  //             3:30    Iran    %z    1977 Oct 20 24:00
   {
     &kAtcAllZonePolicyIran /*zone_policy*/,
-    "+0330/+0430" /*format*/,
+    "" /*format*/,
     840 /*offset_code (12600/15)*/,
     0 /*offset_remainder (12600%15)*/,
     0 /*delta_minutes*/,
@@ -21661,10 +21680,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tehran[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    Iran    +04/+05    1979
+  //             4:00    Iran    %z    1979
   {
     &kAtcAllZonePolicyIran /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -21674,10 +21693,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tehran[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:30    Iran    +0330/+0430
+  //             3:30    Iran    %z
   {
     &kAtcAllZonePolicyIran /*zone_policy*/,
-    "+0330/+0430" /*format*/,
+    "" /*format*/,
     840 /*offset_code (12600/15)*/,
     0 /*offset_remainder (12600%15)*/,
     0 /*delta_minutes*/,
@@ -21720,10 +21739,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Thimphu[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:30    -    +0530    1987 Oct
+  //             5:30    -    %z    1987 Oct
   {
     NULL /*zone_policy*/,
-    "+0530" /*format*/,
+    "" /*format*/,
     1320 /*offset_code (19800/15)*/,
     0 /*offset_remainder (19800%15)*/,
     0 /*delta_minutes*/,
@@ -21733,10 +21752,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Thimphu[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06
+  //             6:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -21825,10 +21844,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              6:00    -    +06    1930 Jun 21
+  //              6:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -21838,10 +21857,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    1991 Mar 31  2:00s
+  //              7:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -21851,10 +21870,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    1992 Jan 19  2:00s
+  //              6:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -21864,10 +21883,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    Russia    +07/+08    2002 May  1  3:00
+  //              7:00    Russia    %z    2002 May  1  3:00
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+07/+08" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -21877,10 +21896,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              6:00    Russia    +06/+07    2011 Mar 27  2:00s
+  //              6:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+06/+07" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -21890,10 +21909,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07    2014 Oct 26  2:00s
+  //              7:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -21903,10 +21922,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    -    +06    2016 May 29  2:00s
+  //              6:00    -    %z    2016 May 29  2:00s
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -21916,10 +21935,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Tomsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              7:00    -    +07
+  //              7:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -21962,10 +21981,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ulaanbaatar[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             7:00    -    +07    1978
+  //             7:00    -    %z    1978
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -21975,10 +21994,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ulaanbaatar[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             8:00    Mongol    +08/+09
+  //             8:00    Mongol    %z
   {
     &kAtcAllZonePolicyMongol /*zone_policy*/,
-    "+08/+09" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -22021,10 +22040,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Urumqi[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06
+  //             6:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -22067,10 +22086,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    1930 Jun 21
+  //              8:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -22080,10 +22099,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    Russia    +09/+10    1981 Apr  1
+  //              9:00    Russia    %z    1981 Apr  1
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -22093,10 +22112,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    1991 Mar 31  2:00s
+  //             11:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -22106,10 +22125,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    Russia    +10/+11    1992 Jan 19  2:00s
+  //             10:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -22119,10 +22138,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    Russia    +11/+12    2011 Mar 27  2:00s
+  //             11:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -22132,10 +22151,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             12:00    -    +12    2011 Sep 13  0:00s
+  //             12:00    -    %z    2011 Sep 13  0:00s
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -22145,10 +22164,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     0 /*until_time_code (0/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11    2014 Oct 26  2:00s
+  //             11:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -22158,10 +22177,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Ust_Nera[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10
+  //             10:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -22204,10 +22223,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Vladivostok[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    -    +09    1930 Jun 21
+  //              9:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -22217,10 +22236,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Vladivostok[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             10:00    Russia    +10/+11    1991 Mar 31  2:00s
+  //             10:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -22230,10 +22249,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Vladivostok[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              9:00    Russia    +09/+10    1992 Jan 19  2:00s
+  //              9:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -22243,10 +22262,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Vladivostok[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    Russia    +10/+11    2011 Mar 27  2:00s
+  //             10:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+10/+11" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -22256,10 +22275,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Vladivostok[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11    2014 Oct 26  2:00s
+  //             11:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -22269,10 +22288,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Vladivostok[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10
+  //             10:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -22315,10 +22334,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yakutsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:00    -    +08    1930 Jun 21
+  //              8:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -22328,10 +22347,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yakutsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    Russia    +09/+10    1991 Mar 31  2:00s
+  //              9:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -22341,10 +22360,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yakutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              8:00    Russia    +08/+09    1992 Jan 19  2:00s
+  //              8:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+08/+09" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -22354,10 +22373,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yakutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              9:00    Russia    +09/+10    2011 Mar 27  2:00s
+  //              9:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+09/+10" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -22367,10 +22386,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yakutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             10:00    -    +10    2014 Oct 26  2:00s
+  //             10:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -22380,10 +22399,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yakutsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              9:00    -    +09
+  //              9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -22439,10 +22458,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yangon[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:30    -    +0630    1942 May
+  //             6:30    -    %z    1942 May
   {
     NULL /*zone_policy*/,
-    "+0630" /*format*/,
+    "" /*format*/,
     1560 /*offset_code (23400/15)*/,
     0 /*offset_remainder (23400%15)*/,
     0 /*delta_minutes*/,
@@ -22452,10 +22471,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yangon[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             9:00    -    +09    1945 May  3
+  //             9:00    -    %z    1945 May  3
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -22465,10 +22484,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yangon[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:30    -    +0630
+  //             6:30    -    %z
   {
     NULL /*zone_policy*/,
-    "+0630" /*format*/,
+    "" /*format*/,
     1560 /*offset_code (23400/15)*/,
     0 /*offset_remainder (23400%15)*/,
     0 /*delta_minutes*/,
@@ -22524,10 +22543,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yekaterinburg[]  = {
     960 /*until_time_code (14400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              4:00    -    +04    1930 Jun 21
+  //              4:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -22537,10 +22556,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yekaterinburg[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              5:00    Russia    +05/+06    1991 Mar 31  2:00s
+  //              5:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -22550,10 +22569,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yekaterinburg[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    Russia    +04/+05    1992 Jan 19  2:00s
+  //              4:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -22563,10 +22582,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yekaterinburg[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              5:00    Russia    +05/+06    2011 Mar 27  2:00s
+  //              5:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+05/+06" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -22576,10 +22595,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yekaterinburg[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              6:00    -    +06    2014 Oct 26  2:00s
+  //              6:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -22589,10 +22608,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yekaterinburg[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              5:00    -    +05
+  //              5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -22635,10 +22654,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yerevan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03    1957 Mar
+  //             3:00    -    %z    1957 Mar
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -22648,10 +22667,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yerevan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00 RussiaAsia +04/+05    1991 Mar 31  2:00s
+  //             4:00 RussiaAsia %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -22661,10 +22680,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yerevan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             3:00 RussiaAsia    +03/+04    1995 Sep 24  2:00s
+  //             3:00 RussiaAsia    %z    1995 Sep 24  2:00s
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -22674,10 +22693,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yerevan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             4:00    -    +04    1997
+  //             4:00    -    %z    1997
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -22687,10 +22706,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yerevan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00 RussiaAsia    +04/+05    2011
+  //             4:00 RussiaAsia    %z    2011
   {
     &kAtcAllZonePolicyRussiaAsia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -22700,10 +22719,10 @@ static const AtcZoneEra kAtcZoneEraAsia_Yerevan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00    Armenia    +04/+05
+  //             4:00    Armenia    %z
   {
     &kAtcAllZonePolicyArmenia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -22729,7 +22748,7 @@ const AtcZoneInfo kAtcAllZoneAsia_Yerevan  = {
 
 //---------------------------------------------------------------------------
 // Zone name: Atlantic/Azores
-// Zone Eras: 15
+// Zone Eras: 8
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAtlantic_Azores[]  = {
@@ -22759,150 +22778,59 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Azores[]  = {
     480 /*until_time_code (7200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -2:00    Port    -02/-01    1942 Apr 25 22:00s
+  //             -2:00    Port    %z    1966 Oct  2  2:00s
   {
     &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-02/-01" /*format*/,
-    -480 /*offset_code (-7200/15)*/,
-    0 /*offset_remainder (-7200%15)*/,
-    0 /*delta_minutes*/,
-    1942 /*until_year*/,
-    4 /*until_month*/,
-    25 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -2:00    Port    +00    1942 Aug 15 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "+00" /*format*/,
-    -480 /*offset_code (-7200/15)*/,
-    0 /*offset_remainder (-7200%15)*/,
-    0 /*delta_minutes*/,
-    1942 /*until_year*/,
-    8 /*until_month*/,
-    15 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -2:00    Port    -02/-01    1943 Apr 17 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-02/-01" /*format*/,
-    -480 /*offset_code (-7200/15)*/,
-    0 /*offset_remainder (-7200%15)*/,
-    0 /*delta_minutes*/,
-    1943 /*until_year*/,
-    4 /*until_month*/,
-    17 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -2:00    Port    +00    1943 Aug 28 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "+00" /*format*/,
-    -480 /*offset_code (-7200/15)*/,
-    0 /*offset_remainder (-7200%15)*/,
-    0 /*delta_minutes*/,
-    1943 /*until_year*/,
-    8 /*until_month*/,
-    28 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -2:00    Port    -02/-01    1944 Apr 22 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-02/-01" /*format*/,
-    -480 /*offset_code (-7200/15)*/,
-    0 /*offset_remainder (-7200%15)*/,
-    0 /*delta_minutes*/,
-    1944 /*until_year*/,
-    4 /*until_month*/,
-    22 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -2:00    Port    +00    1944 Aug 26 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "+00" /*format*/,
-    -480 /*offset_code (-7200/15)*/,
-    0 /*offset_remainder (-7200%15)*/,
-    0 /*delta_minutes*/,
-    1944 /*until_year*/,
-    8 /*until_month*/,
-    26 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -2:00    Port    -02/-01    1945 Apr 21 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-02/-01" /*format*/,
-    -480 /*offset_code (-7200/15)*/,
-    0 /*offset_remainder (-7200%15)*/,
-    0 /*delta_minutes*/,
-    1945 /*until_year*/,
-    4 /*until_month*/,
-    21 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -2:00    Port    +00    1945 Aug 25 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "+00" /*format*/,
-    -480 /*offset_code (-7200/15)*/,
-    0 /*offset_remainder (-7200%15)*/,
-    0 /*delta_minutes*/,
-    1945 /*until_year*/,
-    8 /*until_month*/,
-    25 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -2:00    Port    -02/-01    1966 Apr  3  2:00
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-02/-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
     1966 /*until_year*/,
-    4 /*until_month*/,
-    3 /*until_day*/,
+    10 /*until_month*/,
+    2 /*until_day*/,
     480 /*until_time_code (7200/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             -1:00    Port    -01/+00    1983 Sep 25  1:00s
+  //             -1:00    -    %z    1982 Mar 28  0:00s
   {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-01/+00" /*format*/,
+    NULL /*zone_policy*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
-    1983 /*until_year*/,
-    9 /*until_month*/,
-    25 /*until_day*/,
-    240 /*until_time_code (3600/15)*/,
+    1982 /*until_year*/,
+    3 /*until_month*/,
+    28 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             -1:00    W-Eur    -01/+00    1992 Sep 27  1:00s
+  //             -1:00    Port    %z    1986
   {
-    &kAtcAllZonePolicyW_Eur /*zone_policy*/,
-    "-01/+00" /*format*/,
+    &kAtcAllZonePolicyPort /*zone_policy*/,
+    "" /*format*/,
+    -240 /*offset_code (-3600/15)*/,
+    0 /*offset_remainder (-3600%15)*/,
+    0 /*delta_minutes*/,
+    1986 /*until_year*/,
+    1 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+  },
+  //             -1:00    EU    %z    1992 Dec 27  1:00s
+  {
+    &kAtcAllZonePolicyEU /*zone_policy*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
     1992 /*until_year*/,
-    9 /*until_month*/,
+    12 /*until_month*/,
     27 /*until_day*/,
     240 /*until_time_code (3600/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              0:00    EU    WE%sT    1993 Mar 28  1:00u
+  //              0:00    EU    WE%sT    1993 Jun 17  1:00u
   {
     &kAtcAllZonePolicyEU /*zone_policy*/,
     "WE%T" /*format*/,
@@ -22910,15 +22838,15 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Azores[]  = {
     0 /*offset_remainder (0%15)*/,
     0 /*delta_minutes*/,
     1993 /*until_year*/,
-    3 /*until_month*/,
-    28 /*until_day*/,
+    6 /*until_month*/,
+    17 /*until_day*/,
     240 /*until_time_code (3600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -1:00    EU    -01/+00
+  //             -1:00    EU    %z
   {
     &kAtcAllZonePolicyEU /*zone_policy*/,
-    "-01/+00" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -22937,7 +22865,7 @@ const AtcZoneInfo kAtcAllZoneAtlantic_Azores  = {
   kAtcZoneNameAtlantic_Azores /*name*/,
   0xf93ed918 /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  15 /*num_eras*/,
+  8 /*num_eras*/,
   kAtcZoneEraAtlantic_Azores /*eras*/,
   NULL /*target_info*/,
 };
@@ -23046,10 +22974,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Canary[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -1:00    -    -01    1946 Sep 30  1:00
+  //             -1:00    -    %z    1946 Sep 30  1:00
   {
     NULL /*zone_policy*/,
-    "-01" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -23131,10 +23059,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Cape_Verde[]  = {
     480 /*until_time_code (7200/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -2:00    -    -02    1942 Sep
+  //             -2:00    -    %z    1942 Sep
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -23144,10 +23072,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Cape_Verde[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    1:00    -01    1945 Oct 15
+  //             -2:00    1:00    %z    1945 Oct 15
   {
     NULL /*zone_policy*/,
-    "-01" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     60 /*delta_minutes*/,
@@ -23157,10 +23085,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Cape_Verde[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    -    -02    1975 Nov 25  2:00
+  //             -2:00    -    %z    1975 Nov 25  2:00
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -23170,10 +23098,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Cape_Verde[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -1:00    -    -01
+  //             -1:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-01" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -23258,7 +23186,7 @@ const AtcZoneInfo kAtcAllZoneAtlantic_Faroe  = {
 
 //---------------------------------------------------------------------------
 // Zone name: Atlantic/Madeira
-// Zone Eras: 13
+// Zone Eras: 6
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAtlantic_Madeira[]  = {
@@ -23288,135 +23216,44 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Madeira[]  = {
     240 /*until_time_code (3600/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -1:00    Port    -01/+00    1942 Apr 25 22:00s
+  //             -1:00    Port    %z    1966 Oct  2  2:00s
   {
     &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-01/+00" /*format*/,
-    -240 /*offset_code (-3600/15)*/,
-    0 /*offset_remainder (-3600%15)*/,
-    0 /*delta_minutes*/,
-    1942 /*until_year*/,
-    4 /*until_month*/,
-    25 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -1:00    Port    +01    1942 Aug 15 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "+01" /*format*/,
-    -240 /*offset_code (-3600/15)*/,
-    0 /*offset_remainder (-3600%15)*/,
-    0 /*delta_minutes*/,
-    1942 /*until_year*/,
-    8 /*until_month*/,
-    15 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -1:00    Port    -01/+00    1943 Apr 17 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-01/+00" /*format*/,
-    -240 /*offset_code (-3600/15)*/,
-    0 /*offset_remainder (-3600%15)*/,
-    0 /*delta_minutes*/,
-    1943 /*until_year*/,
-    4 /*until_month*/,
-    17 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -1:00    Port    +01    1943 Aug 28 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "+01" /*format*/,
-    -240 /*offset_code (-3600/15)*/,
-    0 /*offset_remainder (-3600%15)*/,
-    0 /*delta_minutes*/,
-    1943 /*until_year*/,
-    8 /*until_month*/,
-    28 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -1:00    Port    -01/+00    1944 Apr 22 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-01/+00" /*format*/,
-    -240 /*offset_code (-3600/15)*/,
-    0 /*offset_remainder (-3600%15)*/,
-    0 /*delta_minutes*/,
-    1944 /*until_year*/,
-    4 /*until_month*/,
-    22 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -1:00    Port    +01    1944 Aug 26 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "+01" /*format*/,
-    -240 /*offset_code (-3600/15)*/,
-    0 /*offset_remainder (-3600%15)*/,
-    0 /*delta_minutes*/,
-    1944 /*until_year*/,
-    8 /*until_month*/,
-    26 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -1:00    Port    -01/+00    1945 Apr 21 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-01/+00" /*format*/,
-    -240 /*offset_code (-3600/15)*/,
-    0 /*offset_remainder (-3600%15)*/,
-    0 /*delta_minutes*/,
-    1945 /*until_year*/,
-    4 /*until_month*/,
-    21 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -1:00    Port    +01    1945 Aug 25 22:00s
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "+01" /*format*/,
-    -240 /*offset_code (-3600/15)*/,
-    0 /*offset_remainder (-3600%15)*/,
-    0 /*delta_minutes*/,
-    1945 /*until_year*/,
-    8 /*until_month*/,
-    25 /*until_day*/,
-    5280 /*until_time_code (79200/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
-  },
-  //             -1:00    Port    -01/+00    1966 Apr  3  2:00
-  {
-    &kAtcAllZonePolicyPort /*zone_policy*/,
-    "-01/+00" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
     1966 /*until_year*/,
-    4 /*until_month*/,
-    3 /*until_day*/,
+    10 /*until_month*/,
+    2 /*until_day*/,
     480 /*until_time_code (7200/15)*/,
+    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
+  },
+  //              0:00    -    WET    1982 Apr  4
+  {
+    NULL /*zone_policy*/,
+    "WET" /*format*/,
+    0 /*offset_code (0/15)*/,
+    0 /*offset_remainder (0%15)*/,
+    0 /*delta_minutes*/,
+    1982 /*until_year*/,
+    4 /*until_month*/,
+    4 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              0:00    Port    WE%sT    1983 Sep 25  1:00s
+  //              0:00    Port    WE%sT    1986 Jul 31
   {
     &kAtcAllZonePolicyPort /*zone_policy*/,
     "WE%T" /*format*/,
     0 /*offset_code (0/15)*/,
     0 /*offset_remainder (0%15)*/,
     0 /*delta_minutes*/,
-    1983 /*until_year*/,
-    9 /*until_month*/,
-    25 /*until_day*/,
-    240 /*until_time_code (3600/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
+    1986 /*until_year*/,
+    7 /*until_month*/,
+    31 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
   //              0:00    EU    WE%sT
   {
@@ -23440,7 +23277,7 @@ const AtcZoneInfo kAtcAllZoneAtlantic_Madeira  = {
   kAtcZoneNameAtlantic_Madeira /*name*/,
   0x81b5c037 /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  13 /*num_eras*/,
+  6 /*num_eras*/,
   kAtcZoneEraAtlantic_Madeira /*eras*/,
   NULL /*target_info*/,
 };
@@ -23464,10 +23301,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_South_Georgia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -2:00    -    -02
+  //             -2:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -23523,10 +23360,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Stanley[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Falk    -04/-03    1983 May
+  //             -4:00    Falk    %z    1983 May
   {
     &kAtcAllZonePolicyFalk /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -23536,10 +23373,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Stanley[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    Falk    -03/-02    1985 Sep 15
+  //             -3:00    Falk    %z    1985 Sep 15
   {
     &kAtcAllZonePolicyFalk /*zone_policy*/,
-    "-03/-02" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -23549,10 +23386,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Stanley[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    Falk    -04/-03    2010 Sep  5  2:00
+  //             -4:00    Falk    %z    2010 Sep  5  2:00
   {
     &kAtcAllZonePolicyFalk /*zone_policy*/,
-    "-04/-03" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -23562,10 +23399,10 @@ static const AtcZoneEra kAtcZoneEraAtlantic_Stanley[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -3:00    -    -03
+  //             -3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -23896,10 +23733,10 @@ static const AtcZoneEra kAtcZoneEraAustralia_Eucla[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:45    Aus +0845/+0945    1943 Jul
+  //              8:45    Aus    %z    1943 Jul
   {
     &kAtcAllZonePolicyAus /*zone_policy*/,
-    "+0845/+0945" /*format*/,
+    "" /*format*/,
     2100 /*offset_code (31500/15)*/,
     0 /*offset_remainder (31500%15)*/,
     0 /*delta_minutes*/,
@@ -23909,10 +23746,10 @@ static const AtcZoneEra kAtcZoneEraAustralia_Eucla[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              8:45    AW  +0845/+0945
+  //              8:45    AW    %z
   {
     &kAtcAllZonePolicyAW /*zone_policy*/,
-    "+0845/+0945" /*format*/,
+    "" /*format*/,
     2100 /*offset_code (31500/15)*/,
     0 /*offset_remainder (31500%15)*/,
     0 /*delta_minutes*/,
@@ -24112,10 +23949,10 @@ static const AtcZoneEra kAtcZoneEraAustralia_Lord_Howe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             10:30    LH    +1030/+1130 1985 Jul
+  //             10:30    LH    %z    1985 Jul
   {
     &kAtcAllZonePolicyLH /*zone_policy*/,
-    "+1030/+1130" /*format*/,
+    "" /*format*/,
     2520 /*offset_code (37800/15)*/,
     0 /*offset_remainder (37800%15)*/,
     0 /*delta_minutes*/,
@@ -24125,10 +23962,10 @@ static const AtcZoneEra kAtcZoneEraAustralia_Lord_Howe[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             10:30    LH    +1030/+11
+  //             10:30    LH    %z
   {
     &kAtcAllZonePolicyLH /*zone_policy*/,
-    "+1030/+11" /*format*/,
+    "" /*format*/,
     2520 /*offset_code (37800/15)*/,
     0 /*offset_remainder (37800%15)*/,
     0 /*delta_minutes*/,
@@ -24330,171 +24167,6 @@ const AtcZoneInfo kAtcAllZoneAustralia_Sydney  = {
 };
 
 //---------------------------------------------------------------------------
-// Zone name: CET
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraCET[]  = {
-  // 1:00 C-Eur CE%sT
-  {
-    &kAtcAllZonePolicyC_Eur /*zone_policy*/,
-    "CE%T" /*format*/,
-    240 /*offset_code (3600/15)*/,
-    0 /*offset_remainder (3600%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameCET[]  = "CET";
-
-const AtcZoneInfo kAtcAllZoneCET  = {
-  kAtcZoneNameCET /*name*/,
-  0x0b87d921 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraCET /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: CST6CDT
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraCST6CDT[]  = {
-  // -6:00 US C%sT
-  {
-    &kAtcAllZonePolicyUS /*zone_policy*/,
-    "C%T" /*format*/,
-    -1440 /*offset_code (-21600/15)*/,
-    0 /*offset_remainder (-21600%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameCST6CDT[]  = "CST6CDT";
-
-const AtcZoneInfo kAtcAllZoneCST6CDT  = {
-  kAtcZoneNameCST6CDT /*name*/,
-  0xf0e87d00 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraCST6CDT /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: EET
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraEET[]  = {
-  // 2:00 EU EE%sT
-  {
-    &kAtcAllZonePolicyEU /*zone_policy*/,
-    "EE%T" /*format*/,
-    480 /*offset_code (7200/15)*/,
-    0 /*offset_remainder (7200%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameEET[]  = "EET";
-
-const AtcZoneInfo kAtcAllZoneEET  = {
-  kAtcZoneNameEET /*name*/,
-  0x0b87e1a3 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraEET /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: EST
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraEST[]  = {
-  // -5:00 - EST
-  {
-    NULL /*zone_policy*/,
-    "EST" /*format*/,
-    -1200 /*offset_code (-18000/15)*/,
-    0 /*offset_remainder (-18000%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameEST[]  = "EST";
-
-const AtcZoneInfo kAtcAllZoneEST  = {
-  kAtcZoneNameEST /*name*/,
-  0x0b87e371 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraEST /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: EST5EDT
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraEST5EDT[]  = {
-  // -5:00 US E%sT
-  {
-    &kAtcAllZonePolicyUS /*zone_policy*/,
-    "E%T" /*format*/,
-    -1200 /*offset_code (-18000/15)*/,
-    0 /*offset_remainder (-18000%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameEST5EDT[]  = "EST5EDT";
-
-const AtcZoneInfo kAtcAllZoneEST5EDT  = {
-  kAtcZoneNameEST5EDT /*name*/,
-  0x8adc72a3 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraEST5EDT /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
 // Zone name: Etc/GMT
 // Zone Eras: 1
 //---------------------------------------------------------------------------
@@ -24533,10 +24205,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_1[]  = {
-  // -1 - -01
+  // -1 - %z
   {
     NULL /*zone_policy*/,
-    "-01" /*format*/,
+    "" /*format*/,
     -240 /*offset_code (-3600/15)*/,
     0 /*offset_remainder (-3600%15)*/,
     0 /*delta_minutes*/,
@@ -24566,10 +24238,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_1  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_10[]  = {
-  // -10 - -10
+  // -10 - %z
   {
     NULL /*zone_policy*/,
-    "-10" /*format*/,
+    "" /*format*/,
     -2400 /*offset_code (-36000/15)*/,
     0 /*offset_remainder (-36000%15)*/,
     0 /*delta_minutes*/,
@@ -24599,10 +24271,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_10  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_11[]  = {
-  // -11 - -11
+  // -11 - %z
   {
     NULL /*zone_policy*/,
-    "-11" /*format*/,
+    "" /*format*/,
     -2640 /*offset_code (-39600/15)*/,
     0 /*offset_remainder (-39600%15)*/,
     0 /*delta_minutes*/,
@@ -24632,10 +24304,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_11  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_12[]  = {
-  // -12 - -12
+  // -12 - %z
   {
     NULL /*zone_policy*/,
-    "-12" /*format*/,
+    "" /*format*/,
     -2880 /*offset_code (-43200/15)*/,
     0 /*offset_remainder (-43200%15)*/,
     0 /*delta_minutes*/,
@@ -24665,10 +24337,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_12  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_2[]  = {
-  // -2 - -02
+  // -2 - %z
   {
     NULL /*zone_policy*/,
-    "-02" /*format*/,
+    "" /*format*/,
     -480 /*offset_code (-7200/15)*/,
     0 /*offset_remainder (-7200%15)*/,
     0 /*delta_minutes*/,
@@ -24698,10 +24370,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_2  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_3[]  = {
-  // -3 - -03
+  // -3 - %z
   {
     NULL /*zone_policy*/,
-    "-03" /*format*/,
+    "" /*format*/,
     -720 /*offset_code (-10800/15)*/,
     0 /*offset_remainder (-10800%15)*/,
     0 /*delta_minutes*/,
@@ -24731,10 +24403,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_3  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_4[]  = {
-  // -4 - -04
+  // -4 - %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -24764,10 +24436,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_4  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_5[]  = {
-  // -5 - -05
+  // -5 - %z
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -24797,10 +24469,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_5  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_6[]  = {
-  // -6 - -06
+  // -6 - %z
   {
     NULL /*zone_policy*/,
-    "-06" /*format*/,
+    "" /*format*/,
     -1440 /*offset_code (-21600/15)*/,
     0 /*offset_remainder (-21600%15)*/,
     0 /*delta_minutes*/,
@@ -24830,10 +24502,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_6  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_7[]  = {
-  // -7 - -07
+  // -7 - %z
   {
     NULL /*zone_policy*/,
-    "-07" /*format*/,
+    "" /*format*/,
     -1680 /*offset_code (-25200/15)*/,
     0 /*offset_remainder (-25200%15)*/,
     0 /*delta_minutes*/,
@@ -24863,10 +24535,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_7  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_8[]  = {
-  // -8 - -08
+  // -8 - %z
   {
     NULL /*zone_policy*/,
-    "-08" /*format*/,
+    "" /*format*/,
     -1920 /*offset_code (-28800/15)*/,
     0 /*offset_remainder (-28800%15)*/,
     0 /*delta_minutes*/,
@@ -24896,10 +24568,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_8  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_PLUS_9[]  = {
-  // -9 - -09
+  // -9 - %z
   {
     NULL /*zone_policy*/,
-    "-09" /*format*/,
+    "" /*format*/,
     -2160 /*offset_code (-32400/15)*/,
     0 /*offset_remainder (-32400%15)*/,
     0 /*delta_minutes*/,
@@ -24929,10 +24601,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_9  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_1[]  = {
-  // 1 - +01
+  // 1 - %z
   {
     NULL /*zone_policy*/,
-    "+01" /*format*/,
+    "" /*format*/,
     240 /*offset_code (3600/15)*/,
     0 /*offset_remainder (3600%15)*/,
     0 /*delta_minutes*/,
@@ -24962,10 +24634,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_1  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_10[]  = {
-  // 10 - +10
+  // 10 - %z
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -24995,10 +24667,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_10  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_11[]  = {
-  // 11 - +11
+  // 11 - %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -25028,10 +24700,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_11  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_12[]  = {
-  // 12 - +12
+  // 12 - %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -25061,10 +24733,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_12  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_13[]  = {
-  // 13 - +13
+  // 13 - %z
   {
     NULL /*zone_policy*/,
-    "+13" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -25094,10 +24766,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_13  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_14[]  = {
-  // 14 - +14
+  // 14 - %z
   {
     NULL /*zone_policy*/,
-    "+14" /*format*/,
+    "" /*format*/,
     3360 /*offset_code (50400/15)*/,
     0 /*offset_remainder (50400%15)*/,
     0 /*delta_minutes*/,
@@ -25127,10 +24799,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_14  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_2[]  = {
-  // 2 - +02
+  // 2 - %z
   {
     NULL /*zone_policy*/,
-    "+02" /*format*/,
+    "" /*format*/,
     480 /*offset_code (7200/15)*/,
     0 /*offset_remainder (7200%15)*/,
     0 /*delta_minutes*/,
@@ -25160,10 +24832,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_2  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_3[]  = {
-  // 3 - +03
+  // 3 - %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -25193,10 +24865,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_3  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_4[]  = {
-  // 4 - +04
+  // 4 - %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -25226,10 +24898,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_4  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_5[]  = {
-  // 5 - +05
+  // 5 - %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -25259,10 +24931,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_5  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_6[]  = {
-  // 6 - +06
+  // 6 - %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -25292,10 +24964,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_6  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_7[]  = {
-  // 7 - +07
+  // 7 - %z
   {
     NULL /*zone_policy*/,
-    "+07" /*format*/,
+    "" /*format*/,
     1680 /*offset_code (25200/15)*/,
     0 /*offset_remainder (25200%15)*/,
     0 /*delta_minutes*/,
@@ -25325,10 +24997,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_7  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_8[]  = {
-  // 8 - +08
+  // 8 - %z
   {
     NULL /*zone_policy*/,
-    "+08" /*format*/,
+    "" /*format*/,
     1920 /*offset_code (28800/15)*/,
     0 /*offset_remainder (28800%15)*/,
     0 /*delta_minutes*/,
@@ -25358,10 +25030,10 @@ const AtcZoneInfo kAtcAllZoneEtc_GMT_8  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraEtc_GMT_9[]  = {
-  // 9 - +09
+  // 9 - %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -25509,10 +25181,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              3:00    -    +03    1930 Jun 21
+  //              3:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -25522,10 +25194,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              4:00    Russia    +04/+05    1989 Mar 26  2:00s
+  //              4:00    Russia    %z    1989 Mar 26  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -25535,10 +25207,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    Russia    +03/+04    1991 Mar 31  2:00s
+  //              3:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -25548,10 +25220,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    1992 Mar 29  2:00s
+  //              4:00    -    %z    1992 Mar 29  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -25561,10 +25233,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    Russia    +03/+04    2011 Mar 27  2:00s
+  //              3:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -25574,10 +25246,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    2014 Oct 26  2:00s
+  //              4:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -25587,10 +25259,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    -    +03    2016 Mar 27  2:00s
+  //              3:00    -    %z    2016 Mar 27  2:00s
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -25600,10 +25272,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Astrakhan[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04
+  //              4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -26769,10 +26441,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Istanbul[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    Turkey    +03/+04    1984 Nov  1  2:00
+  //             3:00    Turkey    %z    1984 Nov  1  2:00
   {
     &kAtcAllZonePolicyTurkey /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -26886,10 +26558,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Istanbul[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -26984,10 +26656,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Kaliningrad[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    -    +03    2014 Oct 26  2:00s
+  //              3:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -27043,10 +26715,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Kirov[]  = {
     0 /*until_time_code (0/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //              3:00    -    +03    1930 Jun 21
+  //              3:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -27056,10 +26728,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Kirov[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              4:00    Russia    +04/+05    1989 Mar 26  2:00s
+  //              4:00    Russia    %z    1989 Mar 26  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -27082,10 +26754,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Kirov[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    1992 Mar 29  2:00s
+  //              4:00    -    %z    1992 Mar 29  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -27317,7 +26989,7 @@ static const AtcZoneEra kAtcZoneEraEurope_Lisbon[]  = {
     0 /*until_time_code (0/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //              0:00    Port    WE%sT    1966 Apr  3  2:00
+  //              0:00    Port    WE%sT    1966 Oct  2  2:00s
   {
     &kAtcAllZonePolicyPort /*zone_policy*/,
     "WE%T" /*format*/,
@@ -27325,10 +26997,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Lisbon[]  = {
     0 /*offset_remainder (0%15)*/,
     0 /*delta_minutes*/,
     1966 /*until_year*/,
-    4 /*until_month*/,
-    3 /*until_day*/,
+    10 /*until_month*/,
+    2 /*until_day*/,
     480 /*until_time_code (7200/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
+    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
   //              1:00    -    CET    1976 Sep 26  1:00
   {
@@ -27343,22 +27015,22 @@ static const AtcZoneEra kAtcZoneEraEurope_Lisbon[]  = {
     240 /*until_time_code (3600/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              0:00    Port    WE%sT    1983 Sep 25  1:00s
+  //              0:00    Port    WE%sT    1986
   {
     &kAtcAllZonePolicyPort /*zone_policy*/,
     "WE%T" /*format*/,
     0 /*offset_code (0/15)*/,
     0 /*offset_remainder (0%15)*/,
     0 /*delta_minutes*/,
-    1983 /*until_year*/,
-    9 /*until_month*/,
-    25 /*until_day*/,
-    240 /*until_time_code (3600/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
+    1986 /*until_year*/,
+    1 /*until_month*/,
+    1 /*until_day*/,
+    0 /*until_time_code (0/15)*/,
+    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              0:00    W-Eur    WE%sT    1992 Sep 27  1:00s
+  //              0:00    EU    WE%sT    1992 Sep 27  1:00u
   {
-    &kAtcAllZonePolicyW_Eur /*zone_policy*/,
+    &kAtcAllZonePolicyEU /*zone_policy*/,
     "WE%T" /*format*/,
     0 /*offset_code (0/15)*/,
     0 /*offset_remainder (0%15)*/,
@@ -27367,7 +27039,7 @@ static const AtcZoneEra kAtcZoneEraEurope_Lisbon[]  = {
     9 /*until_month*/,
     27 /*until_day*/,
     240 /*until_time_code (3600/15)*/,
-    16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
+    32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
   //              1:00    EU    CE%sT    1996 Mar 31  1:00u
   {
@@ -27748,10 +27420,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Minsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             3:00    -    +03
+  //             3:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -28492,10 +28164,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     0 /*until_time_code (0/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //              3:00    -    +03    1930 Jun 21
+  //              3:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -28505,10 +28177,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              4:00    -    +04    1935 Jan 27
+  //              4:00    -    %z    1935 Jan 27
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -28518,10 +28190,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              4:00    Russia    +04/+05    1989 Mar 26  2:00s
+  //              4:00    Russia    %z    1989 Mar 26  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -28531,10 +28203,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    Russia    +03/+04    1991 Mar 31  2:00s
+  //              3:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -28544,10 +28216,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              2:00    Russia    +02/+03    1991 Sep 29  2:00s
+  //              2:00    Russia    %z    1991 Sep 29  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+02/+03" /*format*/,
+    "" /*format*/,
     480 /*offset_code (7200/15)*/,
     0 /*offset_remainder (7200%15)*/,
     0 /*delta_minutes*/,
@@ -28557,10 +28229,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    -    +03    1991 Oct 20  3:00
+  //              3:00    -    %z    1991 Oct 20  3:00
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -28570,10 +28242,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              4:00    Russia    +04/+05    2010 Mar 28  2:00s
+  //              4:00    Russia    %z    2010 Mar 28  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -28583,10 +28255,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    Russia    +03/+04    2011 Mar 27  2:00s
+  //              3:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -28596,10 +28268,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Samara[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04
+  //              4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -28642,10 +28314,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     0 /*until_time_code (0/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //              3:00    -    +03    1930 Jun 21
+  //              3:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -28655,10 +28327,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              4:00    Russia    +04/+05    1988 Mar 27  2:00s
+  //              4:00    Russia    %z    1988 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -28668,10 +28340,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    Russia    +03/+04    1991 Mar 31  2:00s
+  //              3:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -28681,10 +28353,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    1992 Mar 29  2:00s
+  //              4:00    -    %z    1992 Mar 29  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -28694,10 +28366,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    Russia    +03/+04    2011 Mar 27  2:00s
+  //              3:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -28707,10 +28379,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    2014 Oct 26  2:00s
+  //              4:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -28720,10 +28392,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    -    +03    2016 Dec  4  2:00s
+  //              3:00    -    %z    2016 Dec  4  2:00s
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -28733,10 +28405,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Saratov[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04
+  //              4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -29405,10 +29077,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     0 /*until_time_code (0/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //              3:00    -    +03    1930 Jun 21
+  //              3:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -29418,10 +29090,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              4:00    Russia    +04/+05    1989 Mar 26  2:00s
+  //              4:00    Russia    %z    1989 Mar 26  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -29431,10 +29103,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    Russia    +03/+04    1991 Mar 31  2:00s
+  //              3:00    Russia    %z    1991 Mar 31  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -29444,10 +29116,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              2:00    Russia    +02/+03    1992 Jan 19  2:00s
+  //              2:00    Russia    %z    1992 Jan 19  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+02/+03" /*format*/,
+    "" /*format*/,
     480 /*offset_code (7200/15)*/,
     0 /*offset_remainder (7200%15)*/,
     0 /*delta_minutes*/,
@@ -29457,10 +29129,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    Russia    +03/+04    2011 Mar 27  2:00s
+  //              3:00    Russia    %z    2011 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+03/+04" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -29470,10 +29142,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    2014 Oct 26  2:00s
+  //              4:00    -    %z    2014 Oct 26  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -29483,10 +29155,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              3:00    -    +03    2016 Mar 27  2:00s
+  //              3:00    -    %z    2016 Mar 27  2:00s
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -29496,10 +29168,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Ulyanovsk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04
+  //              4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -29881,10 +29553,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Volgograd[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              3:00    -    +03    1930 Jun 21
+  //              3:00    -    %z    1930 Jun 21
   {
     NULL /*zone_policy*/,
-    "+03" /*format*/,
+    "" /*format*/,
     720 /*offset_code (10800/15)*/,
     0 /*offset_remainder (10800%15)*/,
     0 /*delta_minutes*/,
@@ -29894,10 +29566,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Volgograd[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              4:00    -    +04    1961 Nov 11
+  //              4:00    -    %z    1961 Nov 11
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -29907,10 +29579,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Volgograd[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              4:00    Russia    +04/+05    1988 Mar 27  2:00s
+  //              4:00    Russia    %z    1988 Mar 27  2:00s
   {
     &kAtcAllZonePolicyRussia /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -29933,10 +29605,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Volgograd[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    1992 Mar 29  2:00s
+  //              4:00    -    %z    1992 Mar 29  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -29985,10 +29657,10 @@ static const AtcZoneEra kAtcZoneEraEurope_Volgograd[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //              4:00    -    +04    2020 Dec 27  2:00s
+  //              4:00    -    %z    2020 Dec 27  2:00s
   {
     NULL /*zone_policy*/,
-    "+04" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -30235,39 +29907,6 @@ const AtcZoneInfo kAtcAllZoneEurope_Zurich  = {
 };
 
 //---------------------------------------------------------------------------
-// Zone name: HST
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraHST[]  = {
-  // -10:00 - HST
-  {
-    NULL /*zone_policy*/,
-    "HST" /*format*/,
-    -2400 /*offset_code (-36000/15)*/,
-    0 /*offset_remainder (-36000%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameHST[]  = "HST";
-
-const AtcZoneInfo kAtcAllZoneHST  = {
-  kAtcZoneNameHST /*name*/,
-  0x0b87f034 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraHST /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
 // Zone name: Indian/Chagos
 // Zone Eras: 3
 //---------------------------------------------------------------------------
@@ -30286,10 +29925,10 @@ static const AtcZoneEra kAtcZoneEraIndian_Chagos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05    1996
+  //             5:00    -    %z    1996
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -30299,10 +29938,10 @@ static const AtcZoneEra kAtcZoneEraIndian_Chagos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             6:00    -    +06
+  //             6:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+06" /*format*/,
+    "" /*format*/,
     1440 /*offset_code (21600/15)*/,
     0 /*offset_remainder (21600%15)*/,
     0 /*delta_minutes*/,
@@ -30358,10 +29997,10 @@ static const AtcZoneEra kAtcZoneEraIndian_Maldives[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             5:00    -    +05
+  //             5:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+05" /*format*/,
+    "" /*format*/,
     1200 /*offset_code (18000/15)*/,
     0 /*offset_remainder (18000%15)*/,
     0 /*delta_minutes*/,
@@ -30404,10 +30043,10 @@ static const AtcZoneEra kAtcZoneEraIndian_Mauritius[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             4:00 Mauritius    +04/+05
+  //             4:00 Mauritius    %z
   {
     &kAtcAllZonePolicyMauritius /*zone_policy*/,
-    "+04/+05" /*format*/,
+    "" /*format*/,
     960 /*offset_code (14400/15)*/,
     0 /*offset_remainder (14400%15)*/,
     0 /*delta_minutes*/,
@@ -30428,138 +30067,6 @@ const AtcZoneInfo kAtcAllZoneIndian_Mauritius  = {
   &kAtcAllZoneContext /*zone_context*/,
   2 /*num_eras*/,
   kAtcZoneEraIndian_Mauritius /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: MET
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraMET[]  = {
-  // 1:00 C-Eur ME%sT
-  {
-    &kAtcAllZonePolicyC_Eur /*zone_policy*/,
-    "ME%T" /*format*/,
-    240 /*offset_code (3600/15)*/,
-    0 /*offset_remainder (3600%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameMET[]  = "MET";
-
-const AtcZoneInfo kAtcAllZoneMET  = {
-  kAtcZoneNameMET /*name*/,
-  0x0b8803ab /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraMET /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: MST
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraMST[]  = {
-  // -7:00 - MST
-  {
-    NULL /*zone_policy*/,
-    "MST" /*format*/,
-    -1680 /*offset_code (-25200/15)*/,
-    0 /*offset_remainder (-25200%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameMST[]  = "MST";
-
-const AtcZoneInfo kAtcAllZoneMST  = {
-  kAtcZoneNameMST /*name*/,
-  0x0b880579 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraMST /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: MST7MDT
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraMST7MDT[]  = {
-  // -7:00 US M%sT
-  {
-    &kAtcAllZonePolicyUS /*zone_policy*/,
-    "M%T" /*format*/,
-    -1680 /*offset_code (-25200/15)*/,
-    0 /*offset_remainder (-25200%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameMST7MDT[]  = "MST7MDT";
-
-const AtcZoneInfo kAtcAllZoneMST7MDT  = {
-  kAtcZoneNameMST7MDT /*name*/,
-  0xf2af9375 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraMST7MDT /*eras*/,
-  NULL /*target_info*/,
-};
-
-//---------------------------------------------------------------------------
-// Zone name: PST8PDT
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraPST8PDT[]  = {
-  // -8:00 US P%sT
-  {
-    &kAtcAllZonePolicyUS /*zone_policy*/,
-    "P%T" /*format*/,
-    -1920 /*offset_code (-28800/15)*/,
-    0 /*offset_remainder (-28800%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNamePST8PDT[]  = "PST8PDT";
-
-const AtcZoneInfo kAtcAllZonePST8PDT  = {
-  kAtcZoneNamePST8PDT /*name*/,
-  0xd99ee2dc /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraPST8PDT /*eras*/,
   NULL /*target_info*/,
 };
 
@@ -30595,10 +30102,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Apia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -11:30    -    -1130    1950
+  //             -11:30    -    %z    1950
   {
     NULL /*zone_policy*/,
-    "-1130" /*format*/,
+    "" /*format*/,
     -2760 /*offset_code (-41400/15)*/,
     0 /*offset_remainder (-41400%15)*/,
     0 /*delta_minutes*/,
@@ -30608,10 +30115,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Apia[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -11:00    WS    -11/-10    2011 Dec 29 24:00
+  //             -11:00    WS    %z    2011 Dec 29 24:00
   {
     &kAtcAllZonePolicyWS /*zone_policy*/,
-    "-11/-10" /*format*/,
+    "" /*format*/,
     -2640 /*offset_code (-39600/15)*/,
     0 /*offset_remainder (-39600%15)*/,
     0 /*delta_minutes*/,
@@ -30621,10 +30128,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Apia[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              13:00    WS    +13/+14
+  //              13:00    WS    %z
   {
     &kAtcAllZonePolicyWS /*zone_policy*/,
-    "+13/+14" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -30739,10 +30246,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Bougainville[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             10:00    -    +10    1942 Jul
+  //             10:00    -    %z    1942 Jul
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -30752,10 +30259,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Bougainville[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    -    +09    1945 Aug 21
+  //              9:00    -    %z    1945 Aug 21
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -30765,10 +30272,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Bougainville[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             10:00    -    +10    2014 Dec 28  2:00
+  //             10:00    -    %z    2014 Dec 28  2:00
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -30778,10 +30285,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Bougainville[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -30824,10 +30331,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Chatham[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             12:15    -    +1215    1946 Jan  1
+  //             12:15    -    %z    1946 Jan  1
   {
     NULL /*zone_policy*/,
-    "+1215" /*format*/,
+    "" /*format*/,
     2940 /*offset_code (44100/15)*/,
     0 /*offset_remainder (44100%15)*/,
     0 /*delta_minutes*/,
@@ -30837,10 +30344,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Chatham[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             12:45    Chatham    +1245/+1345
+  //             12:45    Chatham    %z
   {
     &kAtcAllZonePolicyChatham /*zone_policy*/,
-    "+1245/+1345" /*format*/,
+    "" /*format*/,
     3060 /*offset_code (45900/15)*/,
     0 /*offset_remainder (45900%15)*/,
     0 /*delta_minutes*/,
@@ -30896,10 +30403,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Easter[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -7:00    Chile    -07/-06    1982 Mar 14 3:00u
+  //             -7:00    Chile    %z    1982 Mar 14 3:00u
   {
     &kAtcAllZonePolicyChile /*zone_policy*/,
-    "-07/-06" /*format*/,
+    "" /*format*/,
     -1680 /*offset_code (-25200/15)*/,
     0 /*offset_remainder (-25200%15)*/,
     0 /*delta_minutes*/,
@@ -30909,10 +30416,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Easter[]  = {
     720 /*until_time_code (10800/15)*/,
     32 /*until_time_modifier (kAtcSuffixU + seconds=0)*/,
   },
-  //             -6:00    Chile    -06/-05
+  //             -6:00    Chile    %z
   {
     &kAtcAllZonePolicyChile /*zone_policy*/,
-    "-06/-05" /*format*/,
+    "" /*format*/,
     -1440 /*offset_code (-21600/15)*/,
     0 /*offset_remainder (-21600%15)*/,
     0 /*delta_minutes*/,
@@ -30955,10 +30462,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Efate[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    Vanuatu    +11/+12
+  //             11:00    Vanuatu    %z
   {
     &kAtcAllZonePolicyVanuatu /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -31001,10 +30508,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Fakaofo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -11:00    -    -11    2011 Dec 30
+  //             -11:00    -    %z    2011 Dec 30
   {
     NULL /*zone_policy*/,
-    "-11" /*format*/,
+    "" /*format*/,
     -2640 /*offset_code (-39600/15)*/,
     0 /*offset_remainder (-39600%15)*/,
     0 /*delta_minutes*/,
@@ -31014,10 +30521,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Fakaofo[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             13:00    -    +13
+  //             13:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+13" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -31060,10 +30567,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Fiji[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             12:00    Fiji    +12/+13
+  //             12:00    Fiji    %z
   {
     &kAtcAllZonePolicyFiji /*zone_policy*/,
-    "+12/+13" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -31106,10 +30613,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Galapagos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -5:00    -    -05    1986
+  //             -5:00    -    %z    1986
   {
     NULL /*zone_policy*/,
-    "-05" /*format*/,
+    "" /*format*/,
     -1200 /*offset_code (-18000/15)*/,
     0 /*offset_remainder (-18000%15)*/,
     0 /*delta_minutes*/,
@@ -31119,10 +30626,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Galapagos[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -6:00    Ecuador    -06/-05
+  //             -6:00    Ecuador    %z
   {
     &kAtcAllZonePolicyEcuador /*zone_policy*/,
-    "-06/-05" /*format*/,
+    "" /*format*/,
     -1440 /*offset_code (-21600/15)*/,
     0 /*offset_remainder (-21600%15)*/,
     0 /*delta_minutes*/,
@@ -31165,10 +30672,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Gambier[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              -9:00    -    -09
+  //              -9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-09" /*format*/,
+    "" /*format*/,
     -2160 /*offset_code (-32400/15)*/,
     0 /*offset_remainder (-32400%15)*/,
     0 /*delta_minutes*/,
@@ -31211,10 +30718,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Guadalcanal[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    -    +11
+  //             11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -31283,10 +30790,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Guam[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    -    +09    1944 Jul 31
+  //              9:00    -    %z    1944 Jul 31
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -31440,10 +30947,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kanton[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -12:00    -    -12    1979 Oct
+  //             -12:00    -    %z    1979 Oct
   {
     NULL /*zone_policy*/,
-    "-12" /*format*/,
+    "" /*format*/,
     -2880 /*offset_code (-43200/15)*/,
     0 /*offset_remainder (-43200%15)*/,
     0 /*delta_minutes*/,
@@ -31453,10 +30960,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kanton[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -11:00    -    -11    1994 Dec 31
+  //             -11:00    -    %z    1994 Dec 31
   {
     NULL /*zone_policy*/,
-    "-11" /*format*/,
+    "" /*format*/,
     -2640 /*offset_code (-39600/15)*/,
     0 /*offset_remainder (-39600%15)*/,
     0 /*delta_minutes*/,
@@ -31466,10 +30973,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kanton[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              13:00    -    +13
+  //              13:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+13" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -31512,10 +31019,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kiritimati[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -10:40    -    -1040    1979 Oct
+  //             -10:40    -    %z    1979 Oct
   {
     NULL /*zone_policy*/,
-    "-1040" /*format*/,
+    "" /*format*/,
     -2560 /*offset_code (-38400/15)*/,
     0 /*offset_remainder (-38400%15)*/,
     0 /*delta_minutes*/,
@@ -31525,10 +31032,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kiritimati[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -10:00    -    -10    1994 Dec 31
+  //             -10:00    -    %z    1994 Dec 31
   {
     NULL /*zone_policy*/,
-    "-10" /*format*/,
+    "" /*format*/,
     -2400 /*offset_code (-36000/15)*/,
     0 /*offset_remainder (-36000%15)*/,
     0 /*delta_minutes*/,
@@ -31538,10 +31045,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kiritimati[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              14:00    -    +14
+  //              14:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+14" /*format*/,
+    "" /*format*/,
     3360 /*offset_code (50400/15)*/,
     0 /*offset_remainder (50400%15)*/,
     0 /*delta_minutes*/,
@@ -31597,10 +31104,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kosrae[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              11:00    -    +11    1914 Oct
+  //              11:00    -    %z    1914 Oct
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -31610,10 +31117,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kosrae[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //               9:00    -    +09    1919 Feb  1
+  //               9:00    -    %z    1919 Feb  1
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -31623,10 +31130,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kosrae[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              11:00    -    +11    1937
+  //              11:00    -    %z    1937
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -31636,10 +31143,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kosrae[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              10:00    -    +10    1941 Apr  1
+  //              10:00    -    %z    1941 Apr  1
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -31649,10 +31156,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kosrae[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //               9:00    -    +09    1945 Aug
+  //               9:00    -    %z    1945 Aug
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -31662,10 +31169,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kosrae[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              11:00    -    +11    1969 Oct
+  //              11:00    -    %z    1969 Oct
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -31675,10 +31182,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kosrae[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              12:00    -    +12    1999
+  //              12:00    -    %z    1999
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -31688,10 +31195,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kosrae[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              11:00    -    +11
+  //              11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -31734,10 +31241,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kwajalein[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              11:00    -    +11    1937
+  //              11:00    -    %z    1937
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -31747,10 +31254,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kwajalein[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              10:00    -    +10    1941 Apr  1
+  //              10:00    -    %z    1941 Apr  1
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -31760,10 +31267,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kwajalein[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //               9:00    -    +09    1944 Feb  6
+  //               9:00    -    %z    1944 Feb  6
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -31773,10 +31280,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kwajalein[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              11:00    -    +11    1969 Oct
+  //              11:00    -    %z    1969 Oct
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -31786,10 +31293,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kwajalein[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -12:00    -    -12    1993 Aug 20 24:00
+  //             -12:00    -    %z    1993 Aug 20 24:00
   {
     NULL /*zone_policy*/,
-    "-12" /*format*/,
+    "" /*format*/,
     -2880 /*offset_code (-43200/15)*/,
     0 /*offset_remainder (-43200%15)*/,
     0 /*delta_minutes*/,
@@ -31799,10 +31306,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Kwajalein[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              12:00    -    +12
+  //              12:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -31845,10 +31352,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Marquesas[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              -9:30    -    -0930
+  //              -9:30    -    %z
   {
     NULL /*zone_policy*/,
-    "-0930" /*format*/,
+    "" /*format*/,
     -2280 /*offset_code (-34200/15)*/,
     0 /*offset_remainder (-34200%15)*/,
     0 /*delta_minutes*/,
@@ -31891,10 +31398,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Nauru[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:30    -    +1130    1942 Aug 29
+  //             11:30    -    %z    1942 Aug 29
   {
     NULL /*zone_policy*/,
-    "+1130" /*format*/,
+    "" /*format*/,
     2760 /*offset_code (41400/15)*/,
     0 /*offset_remainder (41400%15)*/,
     0 /*delta_minutes*/,
@@ -31904,10 +31411,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Nauru[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              9:00    -    +09    1945 Sep  8
+  //              9:00    -    %z    1945 Sep  8
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -31917,10 +31424,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Nauru[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:30    -    +1130    1979 Feb 10  2:00
+  //             11:30    -    %z    1979 Feb 10  2:00
   {
     NULL /*zone_policy*/,
-    "+1130" /*format*/,
+    "" /*format*/,
     2760 /*offset_code (41400/15)*/,
     0 /*offset_remainder (41400%15)*/,
     0 /*delta_minutes*/,
@@ -31930,10 +31437,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Nauru[]  = {
     480 /*until_time_code (7200/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             12:00    -    +12
+  //             12:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -31976,10 +31483,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Niue[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -11:20    -    -1120    1964 Jul
+  //             -11:20    -    %z    1964 Jul
   {
     NULL /*zone_policy*/,
-    "-1120" /*format*/,
+    "" /*format*/,
     -2720 /*offset_code (-40800/15)*/,
     0 /*offset_remainder (-40800%15)*/,
     0 /*delta_minutes*/,
@@ -31989,10 +31496,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Niue[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -11:00    -    -11
+  //             -11:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-11" /*format*/,
+    "" /*format*/,
     -2640 /*offset_code (-39600/15)*/,
     0 /*offset_remainder (-39600%15)*/,
     0 /*delta_minutes*/,
@@ -32035,10 +31542,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Norfolk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:12    -    +1112    1951
+  //             11:12    -    %z    1951
   {
     NULL /*zone_policy*/,
-    "+1112" /*format*/,
+    "" /*format*/,
     2688 /*offset_code (40320/15)*/,
     0 /*offset_remainder (40320%15)*/,
     0 /*delta_minutes*/,
@@ -32048,10 +31555,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Norfolk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:30    -    +1130    1974 Oct 27 02:00s
+  //             11:30    -    %z    1974 Oct 27 02:00s
   {
     NULL /*zone_policy*/,
-    "+1130" /*format*/,
+    "" /*format*/,
     2760 /*offset_code (41400/15)*/,
     0 /*offset_remainder (41400%15)*/,
     0 /*delta_minutes*/,
@@ -32061,10 +31568,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Norfolk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:30    1:00    +1230    1975 Mar  2 02:00s
+  //             11:30    1:00    %z    1975 Mar  2 02:00s
   {
     NULL /*zone_policy*/,
-    "+1230" /*format*/,
+    "" /*format*/,
     2760 /*offset_code (41400/15)*/,
     0 /*offset_remainder (41400%15)*/,
     60 /*delta_minutes*/,
@@ -32074,10 +31581,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Norfolk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:30    -    +1130    2015 Oct  4 02:00s
+  //             11:30    -    %z    2015 Oct  4 02:00s
   {
     NULL /*zone_policy*/,
-    "+1130" /*format*/,
+    "" /*format*/,
     2760 /*offset_code (41400/15)*/,
     0 /*offset_remainder (41400%15)*/,
     0 /*delta_minutes*/,
@@ -32087,10 +31594,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Norfolk[]  = {
     480 /*until_time_code (7200/15)*/,
     16 /*until_time_modifier (kAtcSuffixS + seconds=0)*/,
   },
-  //             11:00    -    +11    2019 Jul
+  //             11:00    -    %z    2019 Jul
   {
     NULL /*zone_policy*/,
-    "+11" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -32100,10 +31607,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Norfolk[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    AN    +11/+12
+  //             11:00    AN    %z
   {
     &kAtcAllZonePolicyAN /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -32146,10 +31653,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Noumea[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             11:00    NC    +11/+12
+  //             11:00    NC    %z
   {
     &kAtcAllZonePolicyNC /*zone_policy*/,
-    "+11/+12" /*format*/,
+    "" /*format*/,
     2640 /*offset_code (39600/15)*/,
     0 /*offset_remainder (39600%15)*/,
     0 /*delta_minutes*/,
@@ -32264,10 +31771,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Palau[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //               9:00    -    +09
+  //               9:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+09" /*format*/,
+    "" /*format*/,
     2160 /*offset_code (32400/15)*/,
     0 /*offset_remainder (32400%15)*/,
     0 /*delta_minutes*/,
@@ -32310,10 +31817,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Pitcairn[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -8:30    -    -0830    1998 Apr 27  0:00
+  //             -8:30    -    %z    1998 Apr 27  0:00
   {
     NULL /*zone_policy*/,
-    "-0830" /*format*/,
+    "" /*format*/,
     -2040 /*offset_code (-30600/15)*/,
     0 /*offset_remainder (-30600%15)*/,
     0 /*delta_minutes*/,
@@ -32323,10 +31830,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Pitcairn[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -8:00    -    -08
+  //             -8:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-08" /*format*/,
+    "" /*format*/,
     -1920 /*offset_code (-28800/15)*/,
     0 /*offset_remainder (-28800%15)*/,
     0 /*delta_minutes*/,
@@ -32382,10 +31889,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Port_Moresby[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             10:00    -    +10
+  //             10:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+10" /*format*/,
+    "" /*format*/,
     2400 /*offset_code (36000/15)*/,
     0 /*offset_remainder (36000%15)*/,
     0 /*delta_minutes*/,
@@ -32441,10 +31948,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Rarotonga[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -10:30    -    -1030    1978 Nov 12
+  //             -10:30    -    %z    1978 Nov 12
   {
     NULL /*zone_policy*/,
-    "-1030" /*format*/,
+    "" /*format*/,
     -2520 /*offset_code (-37800/15)*/,
     0 /*offset_remainder (-37800%15)*/,
     0 /*delta_minutes*/,
@@ -32454,10 +31961,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Rarotonga[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -10:00    Cook    -10/-0930
+  //             -10:00    Cook    %z
   {
     &kAtcAllZonePolicyCook /*zone_policy*/,
-    "-10/-0930" /*format*/,
+    "" /*format*/,
     -2400 /*offset_code (-36000/15)*/,
     0 /*offset_remainder (-36000%15)*/,
     0 /*delta_minutes*/,
@@ -32500,10 +32007,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Tahiti[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -10:00    -    -10
+  //             -10:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-10" /*format*/,
+    "" /*format*/,
     -2400 /*offset_code (-36000/15)*/,
     0 /*offset_remainder (-36000%15)*/,
     0 /*delta_minutes*/,
@@ -32546,10 +32053,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Tarawa[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              12:00    -    +12
+  //              12:00    -    %z
   {
     NULL /*zone_policy*/,
-    "+12" /*format*/,
+    "" /*format*/,
     2880 /*offset_code (43200/15)*/,
     0 /*offset_remainder (43200%15)*/,
     0 /*delta_minutes*/,
@@ -32592,10 +32099,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Tongatapu[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             12:20    -    +1220    1961
+  //             12:20    -    %z    1961
   {
     NULL /*zone_policy*/,
-    "+1220" /*format*/,
+    "" /*format*/,
     2960 /*offset_code (44400/15)*/,
     0 /*offset_remainder (44400%15)*/,
     0 /*delta_minutes*/,
@@ -32605,10 +32112,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Tongatapu[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             13:00    -    +13    1999
+  //             13:00    -    %z    1999
   {
     NULL /*zone_policy*/,
-    "+13" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -32618,10 +32125,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Tongatapu[]  = {
     0 /*until_time_code (0/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             13:00    Tonga    +13/+14
+  //             13:00    Tonga    %z
   {
     &kAtcAllZonePolicyTonga /*zone_policy*/,
-    "+13/+14" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,
@@ -32645,43 +32152,10 @@ const AtcZoneInfo kAtcAllZonePacific_Tongatapu  = {
   NULL /*target_info*/,
 };
 
-//---------------------------------------------------------------------------
-// Zone name: WET
-// Zone Eras: 1
-//---------------------------------------------------------------------------
-
-static const AtcZoneEra kAtcZoneEraWET[]  = {
-  // 0:00 EU WE%sT
-  {
-    &kAtcAllZonePolicyEU /*zone_policy*/,
-    "WE%T" /*format*/,
-    0 /*offset_code (0/15)*/,
-    0 /*offset_remainder (0%15)*/,
-    0 /*delta_minutes*/,
-    32767 /*until_year*/,
-    1 /*until_month*/,
-    1 /*until_day*/,
-    0 /*until_time_code (0/15)*/,
-    0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
-  },
-
-};
-
-static const char kAtcZoneNameWET[]  = "WET";
-
-const AtcZoneInfo kAtcAllZoneWET  = {
-  kAtcZoneNameWET /*name*/,
-  0x0b882e35 /*zone_id*/,
-  &kAtcAllZoneContext /*zone_context*/,
-  1 /*num_eras*/,
-  kAtcZoneEraWET /*eras*/,
-  NULL /*target_info*/,
-};
-
 
 
 //---------------------------------------------------------------------------
-// Links: 245
+// Links: 257
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -33444,7 +32918,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Ensenada  = {
   kAtcZoneNameAmerica_Ensenada /*name*/,
   0x7bc95445 /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  19 /*num_eras*/,
+  25 /*num_eras*/,
   kAtcZoneEraAmerica_Tijuana /*eras*/,
   &kAtcAllZoneAmerica_Tijuana /*target_info*/,
 };
@@ -33774,7 +33248,7 @@ const AtcZoneInfo kAtcAllZoneAmerica_Santa_Isabel  = {
   kAtcZoneNameAmerica_Santa_Isabel /*name*/,
   0xfd18a56c /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  19 /*num_eras*/,
+  25 /*num_eras*/,
   kAtcZoneEraAmerica_Tijuana /*eras*/,
   &kAtcAllZoneAmerica_Tijuana /*target_info*/,
 };
@@ -34077,6 +33551,21 @@ const AtcZoneInfo kAtcAllZoneAsia_Calcutta  = {
   8 /*num_eras*/,
   kAtcZoneEraAsia_Kolkata /*eras*/,
   &kAtcAllZoneAsia_Kolkata /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: Asia/Choibalsan -> Asia/Ulaanbaatar
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameAsia_Choibalsan[]  = "Asia/Choibalsan";
+
+const AtcZoneInfo kAtcAllZoneAsia_Choibalsan  = {
+  kAtcZoneNameAsia_Choibalsan /*name*/,
+  0x928aa4a6 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  3 /*num_eras*/,
+  kAtcZoneEraAsia_Ulaanbaatar /*eras*/,
+  &kAtcAllZoneAsia_Ulaanbaatar /*target_info*/,
 };
 
 //---------------------------------------------------------------------------
@@ -34665,6 +34154,36 @@ const AtcZoneInfo kAtcAllZoneBrazil_West  = {
 };
 
 //---------------------------------------------------------------------------
+// Link name: CET -> Europe/Brussels
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameCET[]  = "CET";
+
+const AtcZoneInfo kAtcAllZoneCET  = {
+  kAtcZoneNameCET /*name*/,
+  0x0b87d921 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  9 /*num_eras*/,
+  kAtcZoneEraEurope_Brussels /*eras*/,
+  &kAtcAllZoneEurope_Brussels /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: CST6CDT -> America/Chicago
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameCST6CDT[]  = "CST6CDT";
+
+const AtcZoneInfo kAtcAllZoneCST6CDT  = {
+  kAtcZoneNameCST6CDT /*name*/,
+  0xf0e87d00 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  8 /*num_eras*/,
+  kAtcZoneEraAmerica_Chicago /*eras*/,
+  &kAtcAllZoneAmerica_Chicago /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
 // Link name: Canada/Atlantic -> America/Halifax
 //---------------------------------------------------------------------------
 
@@ -34827,6 +34346,51 @@ const AtcZoneInfo kAtcAllZoneCuba  = {
   3 /*num_eras*/,
   kAtcZoneEraAmerica_Havana /*eras*/,
   &kAtcAllZoneAmerica_Havana /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: EET -> Europe/Athens
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameEET[]  = "EET";
+
+const AtcZoneInfo kAtcAllZoneEET  = {
+  kAtcZoneNameEET /*name*/,
+  0x0b87e1a3 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  6 /*num_eras*/,
+  kAtcZoneEraEurope_Athens /*eras*/,
+  &kAtcAllZoneEurope_Athens /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: EST -> America/Panama
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameEST[]  = "EST";
+
+const AtcZoneInfo kAtcAllZoneEST  = {
+  kAtcZoneNameEST /*name*/,
+  0x0b87e371 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  3 /*num_eras*/,
+  kAtcZoneEraAmerica_Panama /*eras*/,
+  &kAtcAllZoneAmerica_Panama /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: EST5EDT -> America/New_York
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameEST5EDT[]  = "EST5EDT";
+
+const AtcZoneInfo kAtcAllZoneEST5EDT  = {
+  kAtcZoneNameEST5EDT /*name*/,
+  0x8adc72a3 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  6 /*num_eras*/,
+  kAtcZoneEraAmerica_New_York /*eras*/,
+  &kAtcAllZoneAmerica_New_York /*target_info*/,
 };
 
 //---------------------------------------------------------------------------
@@ -35460,6 +35024,21 @@ const AtcZoneInfo kAtcAllZoneGreenwich  = {
 };
 
 //---------------------------------------------------------------------------
+// Link name: HST -> Pacific/Honolulu
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameHST[]  = "HST";
+
+const AtcZoneInfo kAtcAllZoneHST  = {
+  kAtcZoneNameHST /*name*/,
+  0x0b87f034 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  5 /*num_eras*/,
+  kAtcZoneEraPacific_Honolulu /*eras*/,
+  &kAtcAllZonePacific_Honolulu /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
 // Link name: Hongkong -> Asia/Hong_Kong
 //---------------------------------------------------------------------------
 
@@ -35700,6 +35279,51 @@ const AtcZoneInfo kAtcAllZoneLibya  = {
 };
 
 //---------------------------------------------------------------------------
+// Link name: MET -> Europe/Brussels
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameMET[]  = "MET";
+
+const AtcZoneInfo kAtcAllZoneMET  = {
+  kAtcZoneNameMET /*name*/,
+  0x0b8803ab /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  9 /*num_eras*/,
+  kAtcZoneEraEurope_Brussels /*eras*/,
+  &kAtcAllZoneEurope_Brussels /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: MST -> America/Phoenix
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameMST[]  = "MST";
+
+const AtcZoneInfo kAtcAllZoneMST  = {
+  kAtcZoneNameMST /*name*/,
+  0x0b880579 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  7 /*num_eras*/,
+  kAtcZoneEraAmerica_Phoenix /*eras*/,
+  &kAtcAllZoneAmerica_Phoenix /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: MST7MDT -> America/Denver
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameMST7MDT[]  = "MST7MDT";
+
+const AtcZoneInfo kAtcAllZoneMST7MDT  = {
+  kAtcZoneNameMST7MDT /*name*/,
+  0xf2af9375 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  6 /*num_eras*/,
+  kAtcZoneEraAmerica_Denver /*eras*/,
+  &kAtcAllZoneAmerica_Denver /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
 // Link name: Mexico/BajaNorte -> America/Tijuana
 //---------------------------------------------------------------------------
 
@@ -35709,7 +35333,7 @@ const AtcZoneInfo kAtcAllZoneMexico_BajaNorte  = {
   kAtcZoneNameMexico_BajaNorte /*name*/,
   0xfcf7150f /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  19 /*num_eras*/,
+  25 /*num_eras*/,
   kAtcZoneEraAmerica_Tijuana /*eras*/,
   &kAtcAllZoneAmerica_Tijuana /*target_info*/,
 };
@@ -35724,7 +35348,7 @@ const AtcZoneInfo kAtcAllZoneMexico_BajaSur  = {
   kAtcZoneNameMexico_BajaSur /*name*/,
   0x08ee3641 /*zone_id*/,
   &kAtcAllZoneContext /*zone_context*/,
-  8 /*num_eras*/,
+  7 /*num_eras*/,
   kAtcZoneEraAmerica_Mazatlan /*eras*/,
   &kAtcAllZoneAmerica_Mazatlan /*target_info*/,
 };
@@ -35802,6 +35426,21 @@ const AtcZoneInfo kAtcAllZonePRC  = {
   3 /*num_eras*/,
   kAtcZoneEraAsia_Shanghai /*eras*/,
   &kAtcAllZoneAsia_Shanghai /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: PST8PDT -> America/Los_Angeles
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNamePST8PDT[]  = "PST8PDT";
+
+const AtcZoneInfo kAtcAllZonePST8PDT  = {
+  kAtcZoneNamePST8PDT /*name*/,
+  0xd99ee2dc /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  4 /*num_eras*/,
+  kAtcZoneEraAmerica_Los_Angeles /*eras*/,
+  &kAtcAllZoneAmerica_Los_Angeles /*target_info*/,
 };
 
 //---------------------------------------------------------------------------
@@ -36342,6 +35981,21 @@ const AtcZoneInfo kAtcAllZoneW_SU  = {
   11 /*num_eras*/,
   kAtcZoneEraEurope_Moscow /*eras*/,
   &kAtcAllZoneEurope_Moscow /*target_info*/,
+};
+
+//---------------------------------------------------------------------------
+// Link name: WET -> Europe/Lisbon
+//---------------------------------------------------------------------------
+
+static const char kAtcZoneNameWET[]  = "WET";
+
+const AtcZoneInfo kAtcAllZoneWET  = {
+  kAtcZoneNameWET /*name*/,
+  0x0b882e35 /*zone_id*/,
+  &kAtcAllZoneContext /*zone_context*/,
+  8 /*num_eras*/,
+  kAtcZoneEraEurope_Lisbon /*eras*/,
+  &kAtcAllZoneEurope_Lisbon /*target_info*/,
 };
 
 //---------------------------------------------------------------------------

--- a/src/zonedball/zone_infos.h
+++ b/src/zonedball/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1963
+//   Eras: 1941
 //   Policies: 134
-//   Rules: 2234
+//   Rules: 2231
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 402
-//   Eras: 29445
-//   Zones: 4563
-//   Links: 3185
+//   Eras: 29115
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75879
+//   TOTAL: 74967
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 1072
-//   Eras: 39260
-//   Zones: 8424
-//   Links: 5880
+//   Eras: 38820
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94176
+//   TOTAL: 93154
 //
 // DO NOT EDIT
 
@@ -92,8 +92,8 @@ extern "C" {
 extern const AtcZoneContext kAtcAllZoneContext;
 
 //---------------------------------------------------------------------------
-// Supported zones: 351
-// Supported eras: 1963
+// Supported zones: 339
+// Supported eras: 1941
 //---------------------------------------------------------------------------
 
 extern const AtcZoneInfo kAtcAllZoneAfrica_Abidjan; // Africa/Abidjan
@@ -257,7 +257,6 @@ extern const AtcZoneInfo kAtcAllZoneAsia_Barnaul; // Asia/Barnaul
 extern const AtcZoneInfo kAtcAllZoneAsia_Beirut; // Asia/Beirut
 extern const AtcZoneInfo kAtcAllZoneAsia_Bishkek; // Asia/Bishkek
 extern const AtcZoneInfo kAtcAllZoneAsia_Chita; // Asia/Chita
-extern const AtcZoneInfo kAtcAllZoneAsia_Choibalsan; // Asia/Choibalsan
 extern const AtcZoneInfo kAtcAllZoneAsia_Colombo; // Asia/Colombo
 extern const AtcZoneInfo kAtcAllZoneAsia_Damascus; // Asia/Damascus
 extern const AtcZoneInfo kAtcAllZoneAsia_Dhaka; // Asia/Dhaka
@@ -337,11 +336,6 @@ extern const AtcZoneInfo kAtcAllZoneAustralia_Lord_Howe; // Australia/Lord_Howe
 extern const AtcZoneInfo kAtcAllZoneAustralia_Melbourne; // Australia/Melbourne
 extern const AtcZoneInfo kAtcAllZoneAustralia_Perth; // Australia/Perth
 extern const AtcZoneInfo kAtcAllZoneAustralia_Sydney; // Australia/Sydney
-extern const AtcZoneInfo kAtcAllZoneCET; // CET
-extern const AtcZoneInfo kAtcAllZoneCST6CDT; // CST6CDT
-extern const AtcZoneInfo kAtcAllZoneEET; // EET
-extern const AtcZoneInfo kAtcAllZoneEST; // EST
-extern const AtcZoneInfo kAtcAllZoneEST5EDT; // EST5EDT
 extern const AtcZoneInfo kAtcAllZoneEtc_GMT; // Etc/GMT
 extern const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_1; // Etc/GMT+1
 extern const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_10; // Etc/GMT+10
@@ -408,14 +402,9 @@ extern const AtcZoneInfo kAtcAllZoneEurope_Vilnius; // Europe/Vilnius
 extern const AtcZoneInfo kAtcAllZoneEurope_Volgograd; // Europe/Volgograd
 extern const AtcZoneInfo kAtcAllZoneEurope_Warsaw; // Europe/Warsaw
 extern const AtcZoneInfo kAtcAllZoneEurope_Zurich; // Europe/Zurich
-extern const AtcZoneInfo kAtcAllZoneHST; // HST
 extern const AtcZoneInfo kAtcAllZoneIndian_Chagos; // Indian/Chagos
 extern const AtcZoneInfo kAtcAllZoneIndian_Maldives; // Indian/Maldives
 extern const AtcZoneInfo kAtcAllZoneIndian_Mauritius; // Indian/Mauritius
-extern const AtcZoneInfo kAtcAllZoneMET; // MET
-extern const AtcZoneInfo kAtcAllZoneMST; // MST
-extern const AtcZoneInfo kAtcAllZoneMST7MDT; // MST7MDT
-extern const AtcZoneInfo kAtcAllZonePST8PDT; // PST8PDT
 extern const AtcZoneInfo kAtcAllZonePacific_Apia; // Pacific/Apia
 extern const AtcZoneInfo kAtcAllZonePacific_Auckland; // Pacific/Auckland
 extern const AtcZoneInfo kAtcAllZonePacific_Bougainville; // Pacific/Bougainville
@@ -446,7 +435,6 @@ extern const AtcZoneInfo kAtcAllZonePacific_Rarotonga; // Pacific/Rarotonga
 extern const AtcZoneInfo kAtcAllZonePacific_Tahiti; // Pacific/Tahiti
 extern const AtcZoneInfo kAtcAllZonePacific_Tarawa; // Pacific/Tarawa
 extern const AtcZoneInfo kAtcAllZonePacific_Tongatapu; // Pacific/Tongatapu
-extern const AtcZoneInfo kAtcAllZoneWET; // WET
 
 
 // Zone Ids
@@ -612,7 +600,6 @@ extern const AtcZoneInfo kAtcAllZoneWET; // WET
 #define kAtcAllZoneIdAsia_Beirut 0xa7f3d5fd /* Asia/Beirut */
 #define kAtcAllZoneIdAsia_Bishkek 0xb0728553 /* Asia/Bishkek */
 #define kAtcAllZoneIdAsia_Chita 0x14ae863b /* Asia/Chita */
-#define kAtcAllZoneIdAsia_Choibalsan 0x928aa4a6 /* Asia/Choibalsan */
 #define kAtcAllZoneIdAsia_Colombo 0x0af0e91d /* Asia/Colombo */
 #define kAtcAllZoneIdAsia_Damascus 0x20fbb063 /* Asia/Damascus */
 #define kAtcAllZoneIdAsia_Dhaka 0x14c07b8b /* Asia/Dhaka */
@@ -692,11 +679,6 @@ extern const AtcZoneInfo kAtcAllZoneWET; // WET
 #define kAtcAllZoneIdAustralia_Melbourne 0x0fe559a3 /* Australia/Melbourne */
 #define kAtcAllZoneIdAustralia_Perth 0x8db8269d /* Australia/Perth */
 #define kAtcAllZoneIdAustralia_Sydney 0x4d1e9776 /* Australia/Sydney */
-#define kAtcAllZoneIdCET 0x0b87d921 /* CET */
-#define kAtcAllZoneIdCST6CDT 0xf0e87d00 /* CST6CDT */
-#define kAtcAllZoneIdEET 0x0b87e1a3 /* EET */
-#define kAtcAllZoneIdEST 0x0b87e371 /* EST */
-#define kAtcAllZoneIdEST5EDT 0x8adc72a3 /* EST5EDT */
 #define kAtcAllZoneIdEtc_GMT 0xd8e2de58 /* Etc/GMT */
 #define kAtcAllZoneIdEtc_GMT_PLUS_1 0x9d13da14 /* Etc/GMT+1 */
 #define kAtcAllZoneIdEtc_GMT_PLUS_10 0x3f8f1cc4 /* Etc/GMT+10 */
@@ -763,14 +745,9 @@ extern const AtcZoneInfo kAtcAllZoneWET; // WET
 #define kAtcAllZoneIdEurope_Volgograd 0x3ed0f389 /* Europe/Volgograd */
 #define kAtcAllZoneIdEurope_Warsaw 0x75185c19 /* Europe/Warsaw */
 #define kAtcAllZoneIdEurope_Zurich 0x7d8195b9 /* Europe/Zurich */
-#define kAtcAllZoneIdHST 0x0b87f034 /* HST */
 #define kAtcAllZoneIdIndian_Chagos 0x456f7c3c /* Indian/Chagos */
 #define kAtcAllZoneIdIndian_Maldives 0x9869681c /* Indian/Maldives */
 #define kAtcAllZoneIdIndian_Mauritius 0x7b09c02a /* Indian/Mauritius */
-#define kAtcAllZoneIdMET 0x0b8803ab /* MET */
-#define kAtcAllZoneIdMST 0x0b880579 /* MST */
-#define kAtcAllZoneIdMST7MDT 0xf2af9375 /* MST7MDT */
-#define kAtcAllZoneIdPST8PDT 0xd99ee2dc /* PST8PDT */
 #define kAtcAllZoneIdPacific_Apia 0x23359b5e /* Pacific/Apia */
 #define kAtcAllZoneIdPacific_Auckland 0x25062f86 /* Pacific/Auckland */
 #define kAtcAllZoneIdPacific_Bougainville 0x5e10f7a4 /* Pacific/Bougainville */
@@ -801,11 +778,10 @@ extern const AtcZoneInfo kAtcAllZoneWET; // WET
 #define kAtcAllZoneIdPacific_Tahiti 0xf24c2446 /* Pacific/Tahiti */
 #define kAtcAllZoneIdPacific_Tarawa 0xf2517e63 /* Pacific/Tarawa */
 #define kAtcAllZoneIdPacific_Tongatapu 0x262ca836 /* Pacific/Tongatapu */
-#define kAtcAllZoneIdWET 0x0b882e35 /* WET */
 
 
 //---------------------------------------------------------------------------
-// Supported links: 245
+// Supported links: 257
 //---------------------------------------------------------------------------
 
 extern const AtcZoneInfo kAtcAllZoneAfrica_Accra; // Africa/Accra -> Africa/Abidjan
@@ -901,6 +877,7 @@ extern const AtcZoneInfo kAtcAllZoneAsia_Ashkhabad; // Asia/Ashkhabad -> Asia/As
 extern const AtcZoneInfo kAtcAllZoneAsia_Bahrain; // Asia/Bahrain -> Asia/Qatar
 extern const AtcZoneInfo kAtcAllZoneAsia_Brunei; // Asia/Brunei -> Asia/Kuching
 extern const AtcZoneInfo kAtcAllZoneAsia_Calcutta; // Asia/Calcutta -> Asia/Kolkata
+extern const AtcZoneInfo kAtcAllZoneAsia_Choibalsan; // Asia/Choibalsan -> Asia/Ulaanbaatar
 extern const AtcZoneInfo kAtcAllZoneAsia_Chongqing; // Asia/Chongqing -> Asia/Shanghai
 extern const AtcZoneInfo kAtcAllZoneAsia_Chungking; // Asia/Chungking -> Asia/Shanghai
 extern const AtcZoneInfo kAtcAllZoneAsia_Dacca; // Asia/Dacca -> Asia/Dhaka
@@ -940,6 +917,8 @@ extern const AtcZoneInfo kAtcAllZoneBrazil_Acre; // Brazil/Acre -> America/Rio_B
 extern const AtcZoneInfo kAtcAllZoneBrazil_DeNoronha; // Brazil/DeNoronha -> America/Noronha
 extern const AtcZoneInfo kAtcAllZoneBrazil_East; // Brazil/East -> America/Sao_Paulo
 extern const AtcZoneInfo kAtcAllZoneBrazil_West; // Brazil/West -> America/Manaus
+extern const AtcZoneInfo kAtcAllZoneCET; // CET -> Europe/Brussels
+extern const AtcZoneInfo kAtcAllZoneCST6CDT; // CST6CDT -> America/Chicago
 extern const AtcZoneInfo kAtcAllZoneCanada_Atlantic; // Canada/Atlantic -> America/Halifax
 extern const AtcZoneInfo kAtcAllZoneCanada_Central; // Canada/Central -> America/Winnipeg
 extern const AtcZoneInfo kAtcAllZoneCanada_Eastern; // Canada/Eastern -> America/Toronto
@@ -951,6 +930,9 @@ extern const AtcZoneInfo kAtcAllZoneCanada_Yukon; // Canada/Yukon -> America/Whi
 extern const AtcZoneInfo kAtcAllZoneChile_Continental; // Chile/Continental -> America/Santiago
 extern const AtcZoneInfo kAtcAllZoneChile_EasterIsland; // Chile/EasterIsland -> Pacific/Easter
 extern const AtcZoneInfo kAtcAllZoneCuba; // Cuba -> America/Havana
+extern const AtcZoneInfo kAtcAllZoneEET; // EET -> Europe/Athens
+extern const AtcZoneInfo kAtcAllZoneEST; // EST -> America/Panama
+extern const AtcZoneInfo kAtcAllZoneEST5EDT; // EST5EDT -> America/New_York
 extern const AtcZoneInfo kAtcAllZoneEgypt; // Egypt -> Africa/Cairo
 extern const AtcZoneInfo kAtcAllZoneEire; // Eire -> Europe/Dublin
 extern const AtcZoneInfo kAtcAllZoneEtc_GMT_PLUS_0; // Etc/GMT+0 -> Etc/GMT
@@ -993,6 +975,7 @@ extern const AtcZoneInfo kAtcAllZoneGMT_PLUS_0; // GMT+0 -> Etc/GMT
 extern const AtcZoneInfo kAtcAllZoneGMT_0; // GMT-0 -> Etc/GMT
 extern const AtcZoneInfo kAtcAllZoneGMT0; // GMT0 -> Etc/GMT
 extern const AtcZoneInfo kAtcAllZoneGreenwich; // Greenwich -> Etc/GMT
+extern const AtcZoneInfo kAtcAllZoneHST; // HST -> Pacific/Honolulu
 extern const AtcZoneInfo kAtcAllZoneHongkong; // Hongkong -> Asia/Hong_Kong
 extern const AtcZoneInfo kAtcAllZoneIceland; // Iceland -> Africa/Abidjan
 extern const AtcZoneInfo kAtcAllZoneIndian_Antananarivo; // Indian/Antananarivo -> Africa/Nairobi
@@ -1009,6 +992,9 @@ extern const AtcZoneInfo kAtcAllZoneJamaica; // Jamaica -> America/Jamaica
 extern const AtcZoneInfo kAtcAllZoneJapan; // Japan -> Asia/Tokyo
 extern const AtcZoneInfo kAtcAllZoneKwajalein; // Kwajalein -> Pacific/Kwajalein
 extern const AtcZoneInfo kAtcAllZoneLibya; // Libya -> Africa/Tripoli
+extern const AtcZoneInfo kAtcAllZoneMET; // MET -> Europe/Brussels
+extern const AtcZoneInfo kAtcAllZoneMST; // MST -> America/Phoenix
+extern const AtcZoneInfo kAtcAllZoneMST7MDT; // MST7MDT -> America/Denver
 extern const AtcZoneInfo kAtcAllZoneMexico_BajaNorte; // Mexico/BajaNorte -> America/Tijuana
 extern const AtcZoneInfo kAtcAllZoneMexico_BajaSur; // Mexico/BajaSur -> America/Mazatlan
 extern const AtcZoneInfo kAtcAllZoneMexico_General; // Mexico/General -> America/Mexico_City
@@ -1016,6 +1002,7 @@ extern const AtcZoneInfo kAtcAllZoneNZ; // NZ -> Pacific/Auckland
 extern const AtcZoneInfo kAtcAllZoneNZ_CHAT; // NZ-CHAT -> Pacific/Chatham
 extern const AtcZoneInfo kAtcAllZoneNavajo; // Navajo -> America/Denver
 extern const AtcZoneInfo kAtcAllZonePRC; // PRC -> Asia/Shanghai
+extern const AtcZoneInfo kAtcAllZonePST8PDT; // PST8PDT -> America/Los_Angeles
 extern const AtcZoneInfo kAtcAllZonePacific_Chuuk; // Pacific/Chuuk -> Pacific/Port_Moresby
 extern const AtcZoneInfo kAtcAllZonePacific_Enderbury; // Pacific/Enderbury -> Pacific/Kanton
 extern const AtcZoneInfo kAtcAllZonePacific_Funafuti; // Pacific/Funafuti -> Pacific/Tarawa
@@ -1052,6 +1039,7 @@ extern const AtcZoneInfo kAtcAllZoneUS_Samoa; // US/Samoa -> Pacific/Pago_Pago
 extern const AtcZoneInfo kAtcAllZoneUTC; // UTC -> Etc/UTC
 extern const AtcZoneInfo kAtcAllZoneUniversal; // Universal -> Etc/UTC
 extern const AtcZoneInfo kAtcAllZoneW_SU; // W-SU -> Europe/Moscow
+extern const AtcZoneInfo kAtcAllZoneWET; // WET -> Europe/Lisbon
 extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 
 
@@ -1150,6 +1138,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneIdAsia_Bahrain 0x9d078487 /* Asia/Bahrain */
 #define kAtcAllZoneIdAsia_Brunei 0xa8e595f7 /* Asia/Brunei */
 #define kAtcAllZoneIdAsia_Calcutta 0x328a44c3 /* Asia/Calcutta */
+#define kAtcAllZoneIdAsia_Choibalsan 0x928aa4a6 /* Asia/Choibalsan */
 #define kAtcAllZoneIdAsia_Chongqing 0xf937fb90 /* Asia/Chongqing */
 #define kAtcAllZoneIdAsia_Chungking 0xc7121dd0 /* Asia/Chungking */
 #define kAtcAllZoneIdAsia_Dacca 0x14bcac5e /* Asia/Dacca */
@@ -1189,6 +1178,8 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneIdBrazil_DeNoronha 0x9b4cb496 /* Brazil/DeNoronha */
 #define kAtcAllZoneIdBrazil_East 0x669578c5 /* Brazil/East */
 #define kAtcAllZoneIdBrazil_West 0x669f689b /* Brazil/West */
+#define kAtcAllZoneIdCET 0x0b87d921 /* CET */
+#define kAtcAllZoneIdCST6CDT 0xf0e87d00 /* CST6CDT */
 #define kAtcAllZoneIdCanada_Atlantic 0x536b119c /* Canada/Atlantic */
 #define kAtcAllZoneIdCanada_Central 0x626710f5 /* Canada/Central */
 #define kAtcAllZoneIdCanada_Eastern 0xf3612d5e /* Canada/Eastern */
@@ -1200,6 +1191,9 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneIdChile_Continental 0x7e2bdb18 /* Chile/Continental */
 #define kAtcAllZoneIdChile_EasterIsland 0xb0982af8 /* Chile/EasterIsland */
 #define kAtcAllZoneIdCuba 0x7c83cba0 /* Cuba */
+#define kAtcAllZoneIdEET 0x0b87e1a3 /* EET */
+#define kAtcAllZoneIdEST 0x0b87e371 /* EST */
+#define kAtcAllZoneIdEST5EDT 0x8adc72a3 /* EST5EDT */
 #define kAtcAllZoneIdEgypt 0x0d1a278e /* Egypt */
 #define kAtcAllZoneIdEire 0x7c84b36a /* Eire */
 #define kAtcAllZoneIdEtc_GMT_PLUS_0 0x9d13da13 /* Etc/GMT+0 */
@@ -1242,6 +1236,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneIdGMT_0 0x0d2f706a /* GMT-0 */
 #define kAtcAllZoneIdGMT0 0x7c8550fd /* GMT0 */
 #define kAtcAllZoneIdGreenwich 0xc84d4221 /* Greenwich */
+#define kAtcAllZoneIdHST 0x0b87f034 /* HST */
 #define kAtcAllZoneIdHongkong 0x56d36560 /* Hongkong */
 #define kAtcAllZoneIdIceland 0xe56a35b5 /* Iceland */
 #define kAtcAllZoneIdIndian_Antananarivo 0x9ebf5289 /* Indian/Antananarivo */
@@ -1258,6 +1253,9 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneIdJapan 0x0d712f8f /* Japan */
 #define kAtcAllZoneIdKwajalein 0x0e57afbb /* Kwajalein */
 #define kAtcAllZoneIdLibya 0x0d998b16 /* Libya */
+#define kAtcAllZoneIdMET 0x0b8803ab /* MET */
+#define kAtcAllZoneIdMST 0x0b880579 /* MST */
+#define kAtcAllZoneIdMST7MDT 0xf2af9375 /* MST7MDT */
 #define kAtcAllZoneIdMexico_BajaNorte 0xfcf7150f /* Mexico/BajaNorte */
 #define kAtcAllZoneIdMexico_BajaSur 0x08ee3641 /* Mexico/BajaSur */
 #define kAtcAllZoneIdMexico_General 0x93711d57 /* Mexico/General */
@@ -1265,6 +1263,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneIdNZ_CHAT 0x4d42afda /* NZ-CHAT */
 #define kAtcAllZoneIdNavajo 0xc4ef0e24 /* Navajo */
 #define kAtcAllZoneIdPRC 0x0b88120a /* PRC */
+#define kAtcAllZoneIdPST8PDT 0xd99ee2dc /* PST8PDT */
 #define kAtcAllZoneIdPacific_Chuuk 0x8a090b23 /* Pacific/Chuuk */
 #define kAtcAllZoneIdPacific_Enderbury 0x61599a93 /* Pacific/Enderbury */
 #define kAtcAllZoneIdPacific_Funafuti 0xdb402d65 /* Pacific/Funafuti */
@@ -1301,6 +1300,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneIdUTC 0x0b882791 /* UTC */
 #define kAtcAllZoneIdUniversal 0xd0ff523e /* Universal */
 #define kAtcAllZoneIdW_SU 0x7c8d8ef1 /* W-SU */
+#define kAtcAllZoneIdWET 0x0b882e35 /* WET */
 #define kAtcAllZoneIdZulu 0x7c9069b5 /* Zulu */
 
 
@@ -1323,7 +1323,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneBufSizeAfrica_Juba 4  /* Africa/Juba in 1970 */
 #define kAtcAllZoneBufSizeAfrica_Khartoum 4  /* Africa/Khartoum in 1970 */
 #define kAtcAllZoneBufSizeAfrica_Lagos 2  /* Africa/Lagos in 1905 */
-#define kAtcAllZoneBufSizeAfrica_Maputo 2  /* Africa/Maputo in 1903 */
+#define kAtcAllZoneBufSizeAfrica_Maputo 2  /* Africa/Maputo in 1908 */
 #define kAtcAllZoneBufSizeAfrica_Monrovia 2  /* Africa/Monrovia in 1881 */
 #define kAtcAllZoneBufSizeAfrica_Nairobi 2  /* Africa/Nairobi in 1908 */
 #define kAtcAllZoneBufSizeAfrica_Ndjamena 2  /* Africa/Ndjamena in 1911 */
@@ -1357,7 +1357,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneBufSizeAmerica_Boise 6  /* America/Boise in 1974 */
 #define kAtcAllZoneBufSizeAmerica_Cambridge_Bay 6  /* America/Cambridge_Bay in 2008 */
 #define kAtcAllZoneBufSizeAmerica_Campo_Grande 6  /* America/Campo_Grande in 1964 */
-#define kAtcAllZoneBufSizeAmerica_Cancun 5  /* America/Cancun in 1998 */
+#define kAtcAllZoneBufSizeAmerica_Cancun 5  /* America/Cancun in 1997 */
 #define kAtcAllZoneBufSizeAmerica_Caracas 2  /* America/Caracas in 1889 */
 #define kAtcAllZoneBufSizeAmerica_Cayenne 2  /* America/Cayenne in 1911 */
 #define kAtcAllZoneBufSizeAmerica_Chicago 6  /* America/Chicago in 2008 */
@@ -1383,7 +1383,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneBufSizeAmerica_Guyana 2  /* America/Guyana in 1911 */
 #define kAtcAllZoneBufSizeAmerica_Halifax 6  /* America/Halifax in 1918 */
 #define kAtcAllZoneBufSizeAmerica_Havana 6  /* America/Havana in 2015 */
-#define kAtcAllZoneBufSizeAmerica_Hermosillo 4  /* America/Hermosillo in 1996 */
+#define kAtcAllZoneBufSizeAmerica_Hermosillo 5  /* America/Hermosillo in 1996 */
 #define kAtcAllZoneBufSizeAmerica_Indiana_Indianapolis 6  /* America/Indiana/Indianapolis in 2006 */
 #define kAtcAllZoneBufSizeAmerica_Indiana_Knox 6  /* America/Indiana/Knox in 2006 */
 #define kAtcAllZoneBufSizeAmerica_Indiana_Marengo 6  /* America/Indiana/Marengo in 2006 */
@@ -1473,7 +1473,6 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneBufSizeAsia_Beirut 5  /* Asia/Beirut in 1921 */
 #define kAtcAllZoneBufSizeAsia_Bishkek 5  /* Asia/Bishkek in 1987 */
 #define kAtcAllZoneBufSizeAsia_Chita 6  /* Asia/Chita in 1991 */
-#define kAtcAllZoneBufSizeAsia_Choibalsan 5  /* Asia/Choibalsan in 1983 */
 #define kAtcAllZoneBufSizeAsia_Colombo 3  /* Asia/Colombo in 1942 */
 #define kAtcAllZoneBufSizeAsia_Damascus 6  /* Asia/Damascus in 2008 */
 #define kAtcAllZoneBufSizeAsia_Dhaka 4  /* Asia/Dhaka in 2009 */
@@ -1534,12 +1533,12 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneBufSizeAsia_Yangon 2  /* Asia/Yangon in 1879 */
 #define kAtcAllZoneBufSizeAsia_Yekaterinburg 6  /* Asia/Yekaterinburg in 1991 */
 #define kAtcAllZoneBufSizeAsia_Yerevan 6  /* Asia/Yerevan in 1991 */
-#define kAtcAllZoneBufSizeAtlantic_Azores 8  /* Atlantic/Azores in 1942 */
+#define kAtcAllZoneBufSizeAtlantic_Azores 7  /* Atlantic/Azores in 1942 */
 #define kAtcAllZoneBufSizeAtlantic_Bermuda 6  /* Atlantic/Bermuda in 2008 */
 #define kAtcAllZoneBufSizeAtlantic_Canary 5  /* Atlantic/Canary in 1980 */
 #define kAtcAllZoneBufSizeAtlantic_Cape_Verde 2  /* Atlantic/Cape_Verde in 1911 */
 #define kAtcAllZoneBufSizeAtlantic_Faroe 5  /* Atlantic/Faroe in 1981 */
-#define kAtcAllZoneBufSizeAtlantic_Madeira 8  /* Atlantic/Madeira in 1942 */
+#define kAtcAllZoneBufSizeAtlantic_Madeira 7  /* Atlantic/Madeira in 1942 */
 #define kAtcAllZoneBufSizeAtlantic_South_Georgia 2  /* Atlantic/South_Georgia in 1889 */
 #define kAtcAllZoneBufSizeAtlantic_Stanley 5  /* Atlantic/Stanley in 1938 */
 #define kAtcAllZoneBufSizeAustralia_Adelaide 6  /* Australia/Adelaide in 1942 */
@@ -1553,11 +1552,6 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneBufSizeAustralia_Melbourne 6  /* Australia/Melbourne in 1942 */
 #define kAtcAllZoneBufSizeAustralia_Perth 6  /* Australia/Perth in 1942 */
 #define kAtcAllZoneBufSizeAustralia_Sydney 6  /* Australia/Sydney in 1942 */
-#define kAtcAllZoneBufSizeCET 5  /* CET in 1943 */
-#define kAtcAllZoneBufSizeCST6CDT 6  /* CST6CDT in 2008 */
-#define kAtcAllZoneBufSizeEET 5  /* EET in 1983 */
-#define kAtcAllZoneBufSizeEST 1  /* EST in 1799 */
-#define kAtcAllZoneBufSizeEST5EDT 6  /* EST5EDT in 2008 */
 #define kAtcAllZoneBufSizeEtc_GMT 1  /* Etc/GMT in 1799 */
 #define kAtcAllZoneBufSizeEtc_GMT_PLUS_1 1  /* Etc/GMT+1 in 1799 */
 #define kAtcAllZoneBufSizeEtc_GMT_PLUS_10 1  /* Etc/GMT+10 in 1799 */
@@ -1624,14 +1618,9 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneBufSizeEurope_Volgograd 6  /* Europe/Volgograd in 1988 */
 #define kAtcAllZoneBufSizeEurope_Warsaw 6  /* Europe/Warsaw in 1987 */
 #define kAtcAllZoneBufSizeEurope_Zurich 5  /* Europe/Zurich in 1981 */
-#define kAtcAllZoneBufSizeHST 1  /* HST in 1799 */
 #define kAtcAllZoneBufSizeIndian_Chagos 2  /* Indian/Chagos in 1906 */
 #define kAtcAllZoneBufSizeIndian_Maldives 2  /* Indian/Maldives in 1879 */
 #define kAtcAllZoneBufSizeIndian_Mauritius 3  /* Indian/Mauritius in 1906 */
-#define kAtcAllZoneBufSizeMET 5  /* MET in 1943 */
-#define kAtcAllZoneBufSizeMST 1  /* MST in 1799 */
-#define kAtcAllZoneBufSizeMST7MDT 6  /* MST7MDT in 2008 */
-#define kAtcAllZoneBufSizePST8PDT 6  /* PST8PDT in 2008 */
 #define kAtcAllZoneBufSizePacific_Apia 5  /* Pacific/Apia in 2011 */
 #define kAtcAllZoneBufSizePacific_Auckland 5  /* Pacific/Auckland in 1928 */
 #define kAtcAllZoneBufSizePacific_Bougainville 2  /* Pacific/Bougainville in 1879 */
@@ -1662,7 +1651,6 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 #define kAtcAllZoneBufSizePacific_Tahiti 2  /* Pacific/Tahiti in 1912 */
 #define kAtcAllZoneBufSizePacific_Tarawa 2  /* Pacific/Tarawa in 1900 */
 #define kAtcAllZoneBufSizePacific_Tongatapu 5  /* Pacific/Tongatapu in 1999 */
-#define kAtcAllZoneBufSizeWET 5  /* WET in 1983 */
 
 
 //---------------------------------------------------------------------------
@@ -1683,6 +1671,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // Africa/Bissau {STDOFF '-1:02:20' not multiple of :15 min}
 // Africa/Cairo {STDOFF '2:05:09' not multiple of :15 min}
 // Africa/Casablanca {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-0:30:20' not multiple of :15 min,
 //   Morocco {SAVE '-1:00' is a negative DST}
 // }
@@ -1691,17 +1680,18 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   Spain {SAVE '2:00' different from 1:00}
 // }
 // Africa/El_Aaiun {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-0:52:48' not multiple of :15 min,
 //   Morocco {SAVE '-1:00' is a negative DST}
 // }
 // Africa/Johannesburg {
-//   RULES not fixed but FORMAT is missing '%' or '/',
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '1:52:00' not multiple of :15 min,
 // }
 // Africa/Juba {STDOFF '2:06:28' not multiple of :15 min}
 // Africa/Khartoum {STDOFF '2:10:08' not multiple of :15 min}
 // Africa/Lagos {STDOFF '0:13:35' not multiple of :15 min}
-// Africa/Maputo {STDOFF '2:10:20' not multiple of :15 min}
+// Africa/Maputo {STDOFF '2:10:18' not multiple of :15 min}
 // Africa/Monrovia {
 //   STDOFF '-0:43:08' not multiple of :15 min,
 //   STDOFF '-0:44:30' not multiple of :15 min,
@@ -1740,60 +1730,86 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   UNTIL '14:31:37' not multiple of :01 min,
 //   UNTIL '14:31:37' not multiple of :15 min,
 // }
-// America/Araguaina {STDOFF '-3:12:48' not multiple of :15 min}
+// America/Araguaina {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-3:12:48' not multiple of :15 min,
+// }
 // America/Argentina/Buenos_Aires {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-3:53:48' not multiple of :15 min,
 //   STDOFF '-4:16:48' not multiple of :15 min,
 // }
 // America/Argentina/Catamarca {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:16:48' not multiple of :15 min,
 //   STDOFF '-4:23:08' not multiple of :15 min,
 // }
-// America/Argentina/Cordoba {STDOFF '-4:16:48' not multiple of :15 min}
+// America/Argentina/Cordoba {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-4:16:48' not multiple of :15 min,
+// }
 // America/Argentina/Jujuy {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:16:48' not multiple of :15 min,
 //   STDOFF '-4:21:12' not multiple of :15 min,
 // }
 // America/Argentina/La_Rioja {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:16:48' not multiple of :15 min,
 //   STDOFF '-4:27:24' not multiple of :15 min,
 // }
 // America/Argentina/Mendoza {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:16:48' not multiple of :15 min,
 //   STDOFF '-4:35:16' not multiple of :15 min,
 // }
 // America/Argentina/Rio_Gallegos {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:16:48' not multiple of :15 min,
 //   STDOFF '-4:36:52' not multiple of :15 min,
 // }
 // America/Argentina/Salta {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:16:48' not multiple of :15 min,
 //   STDOFF '-4:21:40' not multiple of :15 min,
 // }
 // America/Argentina/San_Juan {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:16:48' not multiple of :15 min,
 //   STDOFF '-4:34:04' not multiple of :15 min,
 // }
 // America/Argentina/San_Luis {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:16:48' not multiple of :15 min,
 //   STDOFF '-4:25:24' not multiple of :15 min,
 // }
 // America/Argentina/Tucuman {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:16:48' not multiple of :15 min,
 //   STDOFF '-4:20:52' not multiple of :15 min,
 // }
 // America/Argentina/Ushuaia {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:16:48' not multiple of :15 min,
 //   STDOFF '-4:33:12' not multiple of :15 min,
 // }
-// America/Asuncion {STDOFF '-3:50:40' not multiple of :15 min}
-// America/Bahia {STDOFF '-2:34:04' not multiple of :15 min}
+// America/Asuncion {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-3:50:40' not multiple of :15 min,
+// }
+// America/Bahia {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-2:34:04' not multiple of :15 min,
+// }
 // America/Bahia_Banderas {STDOFF '-7:01:00' not multiple of :15 min}
 // America/Barbados {
 //   STDOFF '-3:58:29' not multiple of :15 min,
 //   Barb {SAVE '0:30' different from 1:00}
 // }
-// America/Belem {STDOFF '-3:13:56' not multiple of :15 min}
+// America/Belem {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-3:13:56' not multiple of :15 min,
+// }
 // America/Belize {
 //   STDOFF '-5:52:48' not multiple of :15 min,
 //   Belize {
@@ -1805,10 +1821,19 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '0:30' different from 1:00,
 //   }
 // }
-// America/Boa_Vista {STDOFF '-4:02:40' not multiple of :15 min}
-// America/Bogota {STDOFF '-4:56:16' not multiple of :15 min}
+// America/Boa_Vista {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-4:02:40' not multiple of :15 min,
+// }
+// America/Bogota {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-4:56:16' not multiple of :15 min,
+// }
 // America/Boise {STDOFF '-7:44:49' not multiple of :15 min}
-// America/Campo_Grande {STDOFF '-3:38:28' not multiple of :15 min}
+// America/Campo_Grande {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-3:38:28' not multiple of :15 min,
+// }
 // America/Cancun {STDOFF '-5:47:04' not multiple of :15 min}
 // America/Caracas {
 //   STDOFF '-4:27:40' not multiple of :15 min,
@@ -1819,8 +1844,14 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // America/Chihuahua {STDOFF '-7:04:20' not multiple of :15 min}
 // America/Ciudad_Juarez {STDOFF '-7:05:56' not multiple of :15 min}
 // America/Costa_Rica {STDOFF '-5:36:13' not multiple of :15 min}
-// America/Cuiaba {STDOFF '-3:44:20' not multiple of :15 min}
-// America/Danmarkshavn {STDOFF '-1:14:40' not multiple of :15 min}
+// America/Cuiaba {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-3:44:20' not multiple of :15 min,
+// }
+// America/Danmarkshavn {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-1:14:40' not multiple of :15 min,
+// }
 // America/Dawson {
 //   STDOFF '-9:17:40' not multiple of :15 min,
 //   Yukon {
@@ -1835,10 +1866,16 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   UNTIL '0:01' not multiple of :15 min,
 // }
 // America/Edmonton {STDOFF '-7:33:52' not multiple of :15 min}
-// America/Eirunepe {STDOFF '-4:39:28' not multiple of :15 min}
+// America/Eirunepe {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-4:39:28' not multiple of :15 min,
+// }
 // America/El_Salvador {STDOFF '-5:56:48' not multiple of :15 min}
 // America/Fort_Nelson {STDOFF '-8:10:47' not multiple of :15 min}
-// America/Fortaleza {STDOFF '-2:34:00' not multiple of :15 min}
+// America/Fortaleza {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-2:34:00' not multiple of :15 min,
+// }
 // America/Glace_Bay {STDOFF '-3:59:48' not multiple of :15 min}
 // America/Goose_Bay {
 //   STDOFF '-3:30:52' not multiple of :15 min,
@@ -1855,6 +1892,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // }
 // America/Guatemala {STDOFF '-6:02:04' not multiple of :15 min}
 // America/Guayaquil {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-5:14:00' not multiple of :15 min,
 //   STDOFF '-5:19:20' not multiple of :15 min,
 // }
@@ -1890,6 +1928,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // America/Kentucky/Monticello {STDOFF '-5:39:24' not multiple of :15 min}
 // America/La_Paz {STDOFF '-4:32:36' not multiple of :15 min}
 // America/Lima {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-5:08:12' not multiple of :15 min,
 //   STDOFF '-5:08:36' not multiple of :15 min,
 // }
@@ -1897,12 +1936,18 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   STDOFF '-7:52:58' not multiple of :15 min,
 //   CA {AT '2:01' not multiple of :15 min}
 // }
-// America/Maceio {STDOFF '-2:22:52' not multiple of :15 min}
+// America/Maceio {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-2:22:52' not multiple of :15 min,
+// }
 // America/Managua {
 //   STDOFF '-5:45:08' not multiple of :15 min,
 //   STDOFF '-5:45:12' not multiple of :15 min,
 // }
-// America/Manaus {STDOFF '-4:00:04' not multiple of :15 min}
+// America/Manaus {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-4:00:04' not multiple of :15 min,
+// }
 // America/Martinique {STDOFF '-4:04:20' not multiple of :15 min}
 // America/Mazatlan {STDOFF '-7:05:40' not multiple of :15 min}
 // America/Menominee {STDOFF '-5:50:27' not multiple of :15 min}
@@ -1914,13 +1959,17 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   UNTIL '15:44:55' not multiple of :15 min,
 // }
 // America/Mexico_City {STDOFF '-6:36:36' not multiple of :15 min}
-// America/Miquelon {STDOFF '-3:44:40' not multiple of :15 min}
+// America/Miquelon {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-3:44:40' not multiple of :15 min,
+// }
 // America/Moncton {
 //   STDOFF '-4:19:08' not multiple of :15 min,
 //   Moncton {AT '0:01' not multiple of :15 min}
 // }
 // America/Monterrey {STDOFF '-6:41:16' not multiple of :15 min}
 // America/Montevideo {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-3:44:51' not multiple of :15 min,
 //   Uruguay {
 //     SAVE '0:30' different from 1:00,
@@ -1934,11 +1983,17 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   UNTIL '13:29:35' not multiple of :01 min,
 //   UNTIL '13:29:35' not multiple of :15 min,
 // }
-// America/Noronha {STDOFF '-2:09:40' not multiple of :15 min}
+// America/Noronha {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-2:09:40' not multiple of :15 min,
+// }
 // America/North_Dakota/Beulah {STDOFF '-6:47:07' not multiple of :15 min}
 // America/North_Dakota/Center {STDOFF '-6:45:12' not multiple of :15 min}
 // America/North_Dakota/New_Salem {STDOFF '-6:45:39' not multiple of :15 min}
-// America/Nuuk {STDOFF '-3:26:56' not multiple of :15 min}
+// America/Nuuk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-3:26:56' not multiple of :15 min,
+// }
 // America/Ojinaga {STDOFF '-6:57:40' not multiple of :15 min}
 // America/Panama {
 //   STDOFF '-5:18:08' not multiple of :15 min,
@@ -1957,17 +2012,33 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   STDOFF '-4:49' not multiple of :15 min,
 //   STDOFF '-4:49:20' not multiple of :15 min,
 // }
-// America/Porto_Velho {STDOFF '-4:15:36' not multiple of :15 min}
+// America/Porto_Velho {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-4:15:36' not multiple of :15 min,
+// }
 // America/Puerto_Rico {STDOFF '-4:24:25' not multiple of :15 min}
 // America/Punta_Arenas {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-4:42:45' not multiple of :15 min,
 //   STDOFF '-4:43:40' not multiple of :15 min,
 // }
-// America/Recife {STDOFF '-2:19:36' not multiple of :15 min}
+// America/Recife {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-2:19:36' not multiple of :15 min,
+// }
 // America/Regina {STDOFF '-6:58:36' not multiple of :15 min}
-// America/Rio_Branco {STDOFF '-4:31:12' not multiple of :15 min}
-// America/Santarem {STDOFF '-3:38:48' not multiple of :15 min}
-// America/Santiago {STDOFF '-4:42:45' not multiple of :15 min}
+// America/Rio_Branco {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-4:31:12' not multiple of :15 min,
+// }
+// America/Santarem {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-3:38:48' not multiple of :15 min,
+// }
+// America/Santiago {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-4:42:45' not multiple of :15 min,
+// }
 // America/Santo_Domingo {
 //   STDOFF '-4:39:36' not multiple of :15 min,
 //   STDOFF '-4:40' not multiple of :15 min,
@@ -1978,8 +2049,14 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '0:30' different from 1:00,
 //   }
 // }
-// America/Sao_Paulo {STDOFF '-3:06:28' not multiple of :15 min}
-// America/Scoresbysund {STDOFF '-1:27:52' not multiple of :15 min}
+// America/Sao_Paulo {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-3:06:28' not multiple of :15 min,
+// }
+// America/Scoresbysund {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-1:27:52' not multiple of :15 min,
+// }
 // America/Sitka {
 //   STDOFF '-9:01:13' not multiple of :15 min,
 //   STDOFF '14:58:47' not multiple of :15 min,
@@ -2016,6 +2093,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   UNTIL '15:12:18' not multiple of :15 min,
 // }
 // Antarctica/Casey {UNTIL '0:01' not multiple of :15 min}
+// Antarctica/Palmer {RULES not fixed but FORMAT is missing '%s' or '/'}
 // Antarctica/Troll {
 //   Troll {
 //     LETTER '+00' not single character,
@@ -2023,9 +2101,13 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
-// Asia/Almaty {STDOFF '5:07:48' not multiple of :15 min}
+// Asia/Almaty {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '5:07:48' not multiple of :15 min,
+// }
 // Asia/Amman {STDOFF '2:23:44' not multiple of :15 min}
 // Asia/Anadyr {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '11:49:56' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2037,17 +2119,34 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
-// Asia/Aqtau {STDOFF '3:21:04' not multiple of :15 min}
-// Asia/Aqtobe {STDOFF '3:48:40' not multiple of :15 min}
-// Asia/Ashgabat {STDOFF '3:53:32' not multiple of :15 min}
-// Asia/Atyrau {STDOFF '3:27:44' not multiple of :15 min}
+// Asia/Aqtau {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '3:21:04' not multiple of :15 min,
+// }
+// Asia/Aqtobe {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '3:48:40' not multiple of :15 min,
+// }
+// Asia/Ashgabat {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '3:53:32' not multiple of :15 min,
+// }
+// Asia/Atyrau {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '3:27:44' not multiple of :15 min,
+// }
 // Asia/Baghdad {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '2:57:36' not multiple of :15 min,
 //   STDOFF '2:57:40' not multiple of :15 min,
 // }
-// Asia/Baku {STDOFF '3:19:24' not multiple of :15 min}
+// Asia/Baku {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '3:19:24' not multiple of :15 min,
+// }
 // Asia/Bangkok {STDOFF '6:42:04' not multiple of :15 min}
 // Asia/Barnaul {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '5:35:00' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2060,8 +2159,12 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Asia/Beirut {STDOFF '2:22:00' not multiple of :15 min}
-// Asia/Bishkek {STDOFF '4:58:24' not multiple of :15 min}
+// Asia/Bishkek {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '4:58:24' not multiple of :15 min,
+// }
 // Asia/Chita {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '7:33:52' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2073,7 +2176,6 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
-// Asia/Choibalsan {STDOFF '7:38:00' not multiple of :15 min}
 // Asia/Colombo {
 //   RULES '0:30' different from 1:00,
 //   STDOFF '5:19:24' not multiple of :15 min,
@@ -2081,12 +2183,16 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // }
 // Asia/Damascus {STDOFF '2:25:12' not multiple of :15 min}
 // Asia/Dhaka {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '5:53:20' not multiple of :15 min,
 //   STDOFF '6:01:40' not multiple of :15 min,
 // }
 // Asia/Dili {STDOFF '8:22:20' not multiple of :15 min}
 // Asia/Dubai {STDOFF '3:41:12' not multiple of :15 min}
-// Asia/Dushanbe {STDOFF '4:35:12' not multiple of :15 min}
+// Asia/Dushanbe {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '4:35:12' not multiple of :15 min,
+// }
 // Asia/Famagusta {STDOFF '2:15:48' not multiple of :15 min}
 // Asia/Gaza {
 //   STDOFF '2:17:52' not multiple of :15 min,
@@ -2110,8 +2216,12 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   RULES '0:30' different from 1:00,
 //   STDOFF '7:36:42' not multiple of :15 min,
 // }
-// Asia/Hovd {STDOFF '6:06:36' not multiple of :15 min}
+// Asia/Hovd {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '6:06:36' not multiple of :15 min,
+// }
 // Asia/Irkutsk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '6:57:05' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2139,6 +2249,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // }
 // Asia/Kabul {STDOFF '4:36:48' not multiple of :15 min}
 // Asia/Kamchatka {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '10:34:36' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2156,6 +2267,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   STDOFF '5:45' not multiple of :30 min,
 // }
 // Asia/Khandyga {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '9:02:13' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2173,6 +2285,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   STDOFF '5:53:28' not multiple of :15 min,
 // }
 // Asia/Krasnoyarsk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '6:11:26' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2185,11 +2298,16 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Asia/Kuching {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '7:21:20' not multiple of :15 min,
 //   NBorneo {SAVE '0:20' different from 1:00}
 // }
-// Asia/Macau {STDOFF '7:34:10' not multiple of :15 min}
+// Asia/Macau {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '7:34:10' not multiple of :15 min,
+// }
 // Asia/Magadan {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '10:03:12' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2208,6 +2326,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // }
 // Asia/Nicosia {STDOFF '2:13:28' not multiple of :15 min}
 // Asia/Novokuznetsk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '5:48:48' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2220,6 +2339,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Asia/Novosibirsk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '5:31:40' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2232,6 +2352,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Asia/Omsk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '4:53:30' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2243,14 +2364,24 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
-// Asia/Oral {STDOFF '3:25:24' not multiple of :15 min}
+// Asia/Oral {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '3:25:24' not multiple of :15 min,
+// }
 // Asia/Pontianak {STDOFF '7:17:20' not multiple of :15 min}
 // Asia/Pyongyang {STDOFF '8:23:00' not multiple of :15 min}
 // Asia/Qatar {STDOFF '3:26:08' not multiple of :15 min}
-// Asia/Qostanay {STDOFF '4:14:28' not multiple of :15 min}
-// Asia/Qyzylorda {STDOFF '4:21:52' not multiple of :15 min}
+// Asia/Qostanay {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '4:14:28' not multiple of :15 min,
+// }
+// Asia/Qyzylorda {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '4:21:52' not multiple of :15 min,
+// }
 // Asia/Riyadh {STDOFF '3:06:52' not multiple of :15 min}
 // Asia/Sakhalin {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '9:30:48' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2262,7 +2393,10 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
-// Asia/Samarkand {STDOFF '4:27:53' not multiple of :15 min}
+// Asia/Samarkand {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '4:27:53' not multiple of :15 min,
+// }
 // Asia/Seoul {STDOFF '8:27:52' not multiple of :15 min}
 // Asia/Shanghai {STDOFF '8:05:43' not multiple of :15 min}
 // Asia/Singapore {
@@ -2271,6 +2405,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   STDOFF '7:20' not multiple of :15 min,
 // }
 // Asia/Srednekolymsk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '10:14:52' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2283,12 +2418,22 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Asia/Taipei {STDOFF '8:06:00' not multiple of :15 min}
-// Asia/Tashkent {STDOFF '4:37:11' not multiple of :15 min}
-// Asia/Tbilisi {STDOFF '2:59:11' not multiple of :15 min}
-// Asia/Tehran {STDOFF '3:25:44' not multiple of :15 min}
+// Asia/Tashkent {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '4:37:11' not multiple of :15 min,
+// }
+// Asia/Tbilisi {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '2:59:11' not multiple of :15 min,
+// }
+// Asia/Tehran {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '3:25:44' not multiple of :15 min,
+// }
 // Asia/Thimphu {STDOFF '5:58:36' not multiple of :15 min}
 // Asia/Tokyo {STDOFF '9:18:59' not multiple of :15 min}
 // Asia/Tomsk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '5:39:51' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2300,9 +2445,13 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
-// Asia/Ulaanbaatar {STDOFF '7:07:32' not multiple of :15 min}
+// Asia/Ulaanbaatar {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '7:07:32' not multiple of :15 min,
+// }
 // Asia/Urumqi {STDOFF '5:50:20' not multiple of :15 min}
 // Asia/Ust-Nera {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '9:32:54' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2315,6 +2464,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Asia/Vladivostok {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '8:47:31' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2327,6 +2477,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Asia/Yakutsk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '8:38:58' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2340,6 +2491,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // }
 // Asia/Yangon {STDOFF '6:24:47' not multiple of :15 min}
 // Asia/Yekaterinburg {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '3:45:05' not multiple of :15 min,
 //   STDOFF '4:02:33' not multiple of :15 min,
 //   Russia {
@@ -2352,9 +2504,12 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
-// Asia/Yerevan {STDOFF '2:58:00' not multiple of :15 min}
+// Asia/Yerevan {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '2:58:00' not multiple of :15 min,
+// }
 // Atlantic/Azores {
-//   RULES not fixed but FORMAT is missing '%' or '/',
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-1:42:40' not multiple of :15 min,
 //   STDOFF '-1:54:32' not multiple of :15 min,
 //   Port {SAVE '2:00' different from 1:00}
@@ -2364,23 +2519,28 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // Atlantic/Cape_Verde {STDOFF '-1:34:04' not multiple of :15 min}
 // Atlantic/Faroe {STDOFF '-0:27:04' not multiple of :15 min}
 // Atlantic/Madeira {
-//   RULES not fixed but FORMAT is missing '%' or '/',
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-1:07:36' not multiple of :15 min,
 //   Port {SAVE '2:00' different from 1:00}
 // }
 // Atlantic/South_Georgia {STDOFF '-2:26:08' not multiple of :15 min}
-// Atlantic/Stanley {STDOFF '-3:51:24' not multiple of :15 min}
+// Atlantic/Stanley {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-3:51:24' not multiple of :15 min,
+// }
 // Australia/Adelaide {STDOFF '9:14:20' not multiple of :15 min}
 // Australia/Brisbane {STDOFF '10:12:08' not multiple of :15 min}
 // Australia/Broken_Hill {STDOFF '9:25:48' not multiple of :15 min}
 // Australia/Darwin {STDOFF '8:43:20' not multiple of :15 min}
 // Australia/Eucla {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '8:35:28' not multiple of :15 min,
 //   STDOFF '8:45' not multiple of :30 min,
 // }
 // Australia/Hobart {STDOFF '9:49:16' not multiple of :15 min}
 // Australia/Lindeman {STDOFF '9:55:56' not multiple of :15 min}
 // Australia/Lord_Howe {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '10:36:20' not multiple of :15 min,
 //   LH {SAVE '0:30' different from 1:00}
 // }
@@ -2389,6 +2549,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // Australia/Sydney {STDOFF '10:04:52' not multiple of :15 min}
 // Europe/Andorra {STDOFF '0:06:04' not multiple of :15 min}
 // Europe/Astrakhan {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '3:12:12' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2452,6 +2613,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // }
 // Europe/Helsinki {STDOFF '1:39:49' not multiple of :15 min}
 // Europe/Istanbul {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '1:55:52' not multiple of :15 min,
 //   STDOFF '1:56:56' not multiple of :15 min,
 // }
@@ -2468,6 +2630,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Europe/Kirov {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '3:18:48' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2557,6 +2720,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // }
 // Europe/Rome {STDOFF '0:49:56' not multiple of :15 min}
 // Europe/Samara {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '3:20:20' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2569,6 +2733,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Europe/Saratov {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '3:04:18' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2611,6 +2776,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // }
 // Europe/Tirane {STDOFF '1:19:20' not multiple of :15 min}
 // Europe/Ulyanovsk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '3:13:36' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2638,6 +2804,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   }
 // }
 // Europe/Volgograd {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '2:57:40' not multiple of :15 min,
 //   Russia {
 //     LETTER '+05' not single character,
@@ -2656,8 +2823,12 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // }
 // Indian/Chagos {STDOFF '4:49:40' not multiple of :15 min}
 // Indian/Maldives {STDOFF '4:54:00' not multiple of :15 min}
-// Indian/Mauritius {STDOFF '3:50:00' not multiple of :15 min}
+// Indian/Mauritius {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '3:50:00' not multiple of :15 min,
+// }
 // Pacific/Apia {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-11:26:56' not multiple of :15 min,
 //   STDOFF '12:33:04' not multiple of :15 min,
 // }
@@ -2670,15 +2841,28 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   STDOFF '9:48:32' not multiple of :15 min,
 // }
 // Pacific/Chatham {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '12:13:48' not multiple of :15 min,
 //   STDOFF '12:15' not multiple of :30 min,
 //   STDOFF '12:45' not multiple of :30 min,
 // }
-// Pacific/Easter {STDOFF '-7:17:28' not multiple of :15 min}
-// Pacific/Efate {STDOFF '11:13:16' not multiple of :15 min}
+// Pacific/Easter {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-7:17:28' not multiple of :15 min,
+// }
+// Pacific/Efate {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '11:13:16' not multiple of :15 min,
+// }
 // Pacific/Fakaofo {STDOFF '-11:24:56' not multiple of :15 min}
-// Pacific/Fiji {STDOFF '11:55:44' not multiple of :15 min}
-// Pacific/Galapagos {STDOFF '-5:58:24' not multiple of :15 min}
+// Pacific/Fiji {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '11:55:44' not multiple of :15 min,
+// }
+// Pacific/Galapagos {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '-5:58:24' not multiple of :15 min,
+// }
 // Pacific/Gambier {STDOFF '-8:59:48' not multiple of :15 min}
 // Pacific/Guadalcanal {STDOFF '10:39:48' not multiple of :15 min}
 // Pacific/Guam {
@@ -2706,10 +2890,14 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   STDOFF '-11:20' not multiple of :15 min,
 // }
 // Pacific/Norfolk {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '11:11:52' not multiple of :15 min,
 //   STDOFF '11:12' not multiple of :15 min,
 // }
-// Pacific/Noumea {STDOFF '11:05:48' not multiple of :15 min}
+// Pacific/Noumea {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
+//   STDOFF '11:05:48' not multiple of :15 min,
+// }
 // Pacific/Pago_Pago {
 //   STDOFF '-11:22:48' not multiple of :15 min,
 //   STDOFF '12:37:12' not multiple of :15 min,
@@ -2724,6 +2912,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 //   STDOFF '9:48:40' not multiple of :15 min,
 // }
 // Pacific/Rarotonga {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '-10:39:04' not multiple of :15 min,
 //   STDOFF '13:20:56' not multiple of :15 min,
 //   Cook {SAVE '0:30' different from 1:00}
@@ -2731,6 +2920,7 @@ extern const AtcZoneInfo kAtcAllZoneZulu; // Zulu -> Etc/UTC
 // Pacific/Tahiti {STDOFF '-9:58:16' not multiple of :15 min}
 // Pacific/Tarawa {STDOFF '11:32:04' not multiple of :15 min}
 // Pacific/Tongatapu {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   STDOFF '12:19:12' not multiple of :15 min,
 //   STDOFF '12:20' not multiple of :15 min,
 // }

--- a/src/zonedball/zone_policies.c
+++ b/src/zonedball/zone_policies.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1963
+//   Eras: 1941
 //   Policies: 134
-//   Rules: 2234
+//   Rules: 2231
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 402
-//   Eras: 29445
-//   Zones: 4563
-//   Links: 3185
+//   Eras: 29115
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75879
+//   TOTAL: 74967
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 1072
-//   Eras: 39260
-//   Zones: 8424
-//   Links: 5880
+//   Eras: 38820
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94176
+//   TOTAL: 93154
 //
 // DO NOT EDIT
 
@@ -79,7 +79,7 @@
 
 //---------------------------------------------------------------------------
 // Policies: 134
-// Rules: 2234
+// Rules: 2231
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -14940,15 +14940,15 @@ static const AtcZoneRule kAtcZoneRulesMexico[]  = {
     0 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule    Mexico    1931    only    -    May    1    23:00    1:00    D
+  // Rule    Mexico    1931    only    -    April    30    0:00    1:00    D
   {
     1931 /*from_year*/,
     1931 /*to_year*/,
-    5 /*in_month*/,
+    4 /*in_month*/,
     0 /*on_day_of_week*/,
-    1 /*on_day_of_month*/,
+    30 /*on_day_of_month*/,
     0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
-    5520 /*at_time_code (82800/15)*/,
+    0 /*at_time_code (0/15)*/,
     60 /*delta_minutes*/,
     13 /*letterIndex ("D")*/,
   },
@@ -20906,7 +20906,7 @@ const AtcZonePolicy kAtcAllZonePolicyPoland  = {
 
 //---------------------------------------------------------------------------
 // Policy name: Port
-// Rules: 49
+// Rules: 46
 //---------------------------------------------------------------------------
 
 static const AtcZoneRule kAtcZoneRulesPort[]  = {
@@ -20946,77 +20946,29 @@ static const AtcZoneRule kAtcZoneRulesPort[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule    Port    1917    only    -    Feb    28    23:00s    1:00    S
+  // Rule    Port    1917    1921    -    Mar     1     0:00    1:00    S
   {
     1917 /*from_year*/,
-    1917 /*to_year*/,
-    2 /*in_month*/,
+    1921 /*to_year*/,
+    3 /*in_month*/,
     0 /*on_day_of_week*/,
-    28 /*on_day_of_month*/,
-    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    5520 /*at_time_code (82800/15)*/,
+    1 /*on_day_of_month*/,
+    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
+    0 /*at_time_code (0/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule    Port    1917    1921    -    Oct    14    23:00s    0    -
+  // Rule    Port    1917    1921    -    Oct    14    24:00    0    -
   {
     1917 /*from_year*/,
     1921 /*to_year*/,
     10 /*in_month*/,
     0 /*on_day_of_week*/,
     14 /*on_day_of_month*/,
-    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    5520 /*at_time_code (82800/15)*/,
+    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
+    5760 /*at_time_code (86400/15)*/,
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
-  },
-  // Rule    Port    1918    only    -    Mar     1    23:00s    1:00    S
-  {
-    1918 /*from_year*/,
-    1918 /*to_year*/,
-    3 /*in_month*/,
-    0 /*on_day_of_week*/,
-    1 /*on_day_of_month*/,
-    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    5520 /*at_time_code (82800/15)*/,
-    60 /*delta_minutes*/,
-    25 /*letterIndex ("S")*/,
-  },
-  // Rule    Port    1919    only    -    Feb    28    23:00s    1:00    S
-  {
-    1919 /*from_year*/,
-    1919 /*to_year*/,
-    2 /*in_month*/,
-    0 /*on_day_of_week*/,
-    28 /*on_day_of_month*/,
-    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    5520 /*at_time_code (82800/15)*/,
-    60 /*delta_minutes*/,
-    25 /*letterIndex ("S")*/,
-  },
-  // Rule    Port    1920    only    -    Feb    29    23:00s    1:00    S
-  {
-    1920 /*from_year*/,
-    1920 /*to_year*/,
-    2 /*in_month*/,
-    0 /*on_day_of_week*/,
-    29 /*on_day_of_month*/,
-    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    5520 /*at_time_code (82800/15)*/,
-    60 /*delta_minutes*/,
-    25 /*letterIndex ("S")*/,
-  },
-  // Rule    Port    1921    only    -    Feb    28    23:00s    1:00    S
-  {
-    1921 /*from_year*/,
-    1921 /*to_year*/,
-    2 /*in_month*/,
-    0 /*on_day_of_week*/,
-    28 /*on_day_of_month*/,
-    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    5520 /*at_time_code (82800/15)*/,
-    60 /*delta_minutes*/,
-    25 /*letterIndex ("S")*/,
   },
   // Rule    Port    1924    only    -    Apr    16    23:00s    1:00    S
   {
@@ -21030,13 +20982,13 @@ static const AtcZoneRule kAtcZoneRulesPort[]  = {
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule    Port    1924    only    -    Oct    14    23:00s    0    -
+  // Rule    Port    1924    only    -    Oct     4    23:00s    0    -
   {
     1924 /*from_year*/,
     1924 /*to_year*/,
     10 /*in_month*/,
     0 /*on_day_of_week*/,
-    14 /*on_day_of_month*/,
+    4 /*on_day_of_month*/,
     16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
     5520 /*at_time_code (82800/15)*/,
     0 /*delta_minutes*/,
@@ -21246,13 +21198,13 @@ static const AtcZoneRule kAtcZoneRulesPort[]  = {
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule    Port    1940    1941    -    Oct     5    23:00s    0    -
+  // Rule    Port    1940    only    -    Oct     7    23:00s    0    -
   {
     1940 /*from_year*/,
-    1941 /*to_year*/,
+    1940 /*to_year*/,
     10 /*in_month*/,
     0 /*on_day_of_week*/,
-    5 /*on_day_of_month*/,
+    7 /*on_day_of_month*/,
     16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
     5520 /*at_time_code (82800/15)*/,
     0 /*delta_minutes*/,
@@ -21269,6 +21221,18 @@ static const AtcZoneRule kAtcZoneRulesPort[]  = {
     5520 /*at_time_code (82800/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
+  },
+  // Rule    Port    1941    only    -    Oct     5    23:00s    0    -
+  {
+    1941 /*from_year*/,
+    1941 /*to_year*/,
+    10 /*in_month*/,
+    0 /*on_day_of_week*/,
+    5 /*on_day_of_month*/,
+    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
+    5520 /*at_time_code (82800/15)*/,
+    0 /*delta_minutes*/,
+    0 /*letterIndex ("")*/,
   },
   // Rule    Port    1942    1945    -    Mar    Sat>=8    23:00s    1:00    S
   {
@@ -21378,10 +21342,10 @@ static const AtcZoneRule kAtcZoneRulesPort[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule    Port    1947    1965    -    Apr    Sun>=1     2:00s    1:00    S
+  // Rule    Port    1947    1966    -    Apr    Sun>=1     2:00s    1:00    S
   {
     1947 /*from_year*/,
-    1965 /*to_year*/,
+    1966 /*to_year*/,
     4 /*in_month*/,
     7 /*on_day_of_week*/,
     1 /*on_day_of_month*/,
@@ -21402,43 +21366,55 @@ static const AtcZoneRule kAtcZoneRulesPort[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule    Port    1977    only    -    Mar    27     0:00s    1:00    S
+  // Rule    Port    1976    only    -    Sep    lastSun     1:00    0    -
+  {
+    1976 /*from_year*/,
+    1976 /*to_year*/,
+    9 /*in_month*/,
+    7 /*on_day_of_week*/,
+    0 /*on_day_of_month*/,
+    0 /*at_time_modifier (kAtcSuffixW + seconds=0)*/,
+    240 /*at_time_code (3600/15)*/,
+    0 /*delta_minutes*/,
+    0 /*letterIndex ("")*/,
+  },
+  // Rule    Port    1977    only    -    Mar    lastSun     0:00s    1:00    S
   {
     1977 /*from_year*/,
     1977 /*to_year*/,
     3 /*in_month*/,
-    0 /*on_day_of_week*/,
-    27 /*on_day_of_month*/,
+    7 /*on_day_of_week*/,
+    0 /*on_day_of_month*/,
     16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
     0 /*at_time_code (0/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule    Port    1977    only    -    Sep    25     0:00s    0    -
+  // Rule    Port    1977    only    -    Sep    lastSun     0:00s    0    -
   {
     1977 /*from_year*/,
     1977 /*to_year*/,
     9 /*in_month*/,
-    0 /*on_day_of_week*/,
-    25 /*on_day_of_month*/,
+    7 /*on_day_of_week*/,
+    0 /*on_day_of_month*/,
     16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
     0 /*at_time_code (0/15)*/,
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule    Port    1978    1979    -    Apr    Sun>=1     0:00s    1:00    S
+  // Rule    Port    1978    1980    -    Apr    Sun>=1     1:00s    1:00    S
   {
     1978 /*from_year*/,
-    1979 /*to_year*/,
+    1980 /*to_year*/,
     4 /*in_month*/,
     7 /*on_day_of_week*/,
     1 /*on_day_of_month*/,
     16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    0 /*at_time_code (0/15)*/,
+    240 /*at_time_code (3600/15)*/,
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule    Port    1978    only    -    Oct     1     0:00s    0    -
+  // Rule    Port    1978    only    -    Oct     1     1:00s    0    -
   {
     1978 /*from_year*/,
     1978 /*to_year*/,
@@ -21446,14 +21422,14 @@ static const AtcZoneRule kAtcZoneRulesPort[]  = {
     0 /*on_day_of_week*/,
     1 /*on_day_of_month*/,
     16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    0 /*at_time_code (0/15)*/,
+    240 /*at_time_code (3600/15)*/,
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule    Port    1979    1982    -    Sep    lastSun     1:00s    0    -
+  // Rule    Port    1979    1980    -    Sep    lastSun     1:00s    0    -
   {
     1979 /*from_year*/,
-    1982 /*to_year*/,
+    1980 /*to_year*/,
     9 /*in_month*/,
     7 /*on_day_of_week*/,
     0 /*on_day_of_month*/,
@@ -21462,10 +21438,10 @@ static const AtcZoneRule kAtcZoneRulesPort[]  = {
     0 /*delta_minutes*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule    Port    1980    only    -    Mar    lastSun     0:00s    1:00    S
+  // Rule    Port    1981    1986    -    Mar    lastSun     0:00s    1:00    S
   {
-    1980 /*from_year*/,
-    1980 /*to_year*/,
+    1981 /*from_year*/,
+    1986 /*to_year*/,
     3 /*in_month*/,
     7 /*on_day_of_week*/,
     0 /*on_day_of_month*/,
@@ -21474,36 +21450,24 @@ static const AtcZoneRule kAtcZoneRulesPort[]  = {
     60 /*delta_minutes*/,
     25 /*letterIndex ("S")*/,
   },
-  // Rule    Port    1981    1982    -    Mar    lastSun     1:00s    1:00    S
+  // Rule    Port    1981    1985    -    Sep    lastSun     0:00s    0    -
   {
     1981 /*from_year*/,
-    1982 /*to_year*/,
-    3 /*in_month*/,
+    1985 /*to_year*/,
+    9 /*in_month*/,
     7 /*on_day_of_week*/,
     0 /*on_day_of_month*/,
     16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    240 /*at_time_code (3600/15)*/,
-    60 /*delta_minutes*/,
-    25 /*letterIndex ("S")*/,
-  },
-  // Rule    Port    1983    only    -    Mar    lastSun     2:00s    1:00    S
-  {
-    1983 /*from_year*/,
-    1983 /*to_year*/,
-    3 /*in_month*/,
-    7 /*on_day_of_week*/,
-    0 /*on_day_of_month*/,
-    16 /*at_time_modifier (kAtcSuffixS + seconds=0)*/,
-    480 /*at_time_code (7200/15)*/,
-    60 /*delta_minutes*/,
-    25 /*letterIndex ("S")*/,
+    0 /*at_time_code (0/15)*/,
+    0 /*delta_minutes*/,
+    0 /*letterIndex ("")*/,
   },
 
 };
 
 const AtcZonePolicy kAtcAllZonePolicyPort  = {
   kAtcZoneRulesPort /*rules*/,
-  49 /*num_rules*/,
+  46 /*num_rules*/,
 };
 
 //---------------------------------------------------------------------------

--- a/src/zonedball/zone_policies.h
+++ b/src/zonedball/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1963
+//   Eras: 1941
 //   Policies: 134
-//   Rules: 2234
+//   Rules: 2231
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 402
-//   Eras: 29445
-//   Zones: 4563
-//   Links: 3185
+//   Eras: 29115
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75879
+//   TOTAL: 74967
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 1072
-//   Eras: 39260
-//   Zones: 8424
-//   Links: 5880
+//   Eras: 38820
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94176
+//   TOTAL: 93154
 //
 // DO NOT EDIT
 

--- a/src/zonedball/zone_registry.c
+++ b/src/zonedball/zone_registry.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1963
+//   Eras: 1941
 //   Policies: 134
-//   Rules: 2234
+//   Rules: 2231
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 402
-//   Eras: 29445
-//   Zones: 4563
-//   Links: 3185
+//   Eras: 29115
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75879
+//   TOTAL: 74967
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 1072
-//   Eras: 39260
-//   Zones: 8424
-//   Links: 5880
+//   Eras: 38820
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94176
+//   TOTAL: 93154
 //
 // DO NOT EDIT
 
@@ -81,7 +81,7 @@
 //---------------------------------------------------------------------------
 // Zone Info registry. Sorted by zoneId.
 //---------------------------------------------------------------------------
-const AtcZoneInfo * const kAtcAllZoneRegistry[351]  = {
+const AtcZoneInfo * const kAtcAllZoneRegistry[339]  = {
   &kAtcAllZoneAmerica_St_Johns, // 0x04b14e6e, America/St_Johns
   &kAtcAllZoneAmerica_North_Dakota_New_Salem, // 0x04f9958e, America/North_Dakota/New_Salem
   &kAtcAllZoneAsia_Jakarta, // 0x0506ab50, Asia/Jakarta
@@ -92,13 +92,6 @@ const AtcZoneInfo * const kAtcAllZoneRegistry[351]  = {
   &kAtcAllZoneAmerica_Indiana_Tell_City, // 0x09263612, America/Indiana/Tell_City
   &kAtcAllZoneAmerica_Boa_Vista, // 0x0a7b7efe, America/Boa_Vista
   &kAtcAllZoneAsia_Colombo, // 0x0af0e91d, Asia/Colombo
-  &kAtcAllZoneCET, // 0x0b87d921, CET
-  &kAtcAllZoneEET, // 0x0b87e1a3, EET
-  &kAtcAllZoneEST, // 0x0b87e371, EST
-  &kAtcAllZoneHST, // 0x0b87f034, HST
-  &kAtcAllZoneMET, // 0x0b8803ab, MET
-  &kAtcAllZoneMST, // 0x0b880579, MST
-  &kAtcAllZoneWET, // 0x0b882e35, WET
   &kAtcAllZoneAmerica_Guatemala, // 0x0c8259f7, America/Guatemala
   &kAtcAllZoneAfrica_Monrovia, // 0x0ce90385, Africa/Monrovia
   &kAtcAllZoneAntarctica_Rothera, // 0x0e86d203, Antarctica/Rothera
@@ -253,7 +246,6 @@ const AtcZoneInfo * const kAtcAllZoneRegistry[351]  = {
   &kAtcAllZonePacific_Pitcairn, // 0x8837d8bd, Pacific/Pitcairn
   &kAtcAllZonePacific_Efate, // 0x8a2bce28, Pacific/Efate
   &kAtcAllZonePacific_Nauru, // 0x8acc41ae, Pacific/Nauru
-  &kAtcAllZoneEST5EDT, // 0x8adc72a3, EST5EDT
   &kAtcAllZonePacific_Palau, // 0x8af04a36, Pacific/Palau
   &kAtcAllZoneAmerica_Winnipeg, // 0x8c7dafc7, America/Winnipeg
   &kAtcAllZoneAustralia_Eucla, // 0x8cf99e44, Australia/Eucla
@@ -265,7 +257,6 @@ const AtcZoneInfo * const kAtcAllZoneRegistry[351]  = {
   &kAtcAllZonePacific_Norfolk, // 0x8f4eb4be, Pacific/Norfolk
   &kAtcAllZoneAsia_Yerevan, // 0x9185c8cc, Asia/Yerevan
   &kAtcAllZoneAmerica_Detroit, // 0x925cfbc1, America/Detroit
-  &kAtcAllZoneAsia_Choibalsan, // 0x928aa4a6, Asia/Choibalsan
   &kAtcAllZoneAntarctica_Macquarie, // 0x92f47626, Antarctica/Macquarie
   &kAtcAllZoneAmerica_Belize, // 0x93256c81, America/Belize
   &kAtcAllZoneAmerica_Bogota, // 0x93d7bc62, America/Bogota
@@ -384,7 +375,6 @@ const AtcZoneInfo * const kAtcAllZoneRegistry[351]  = {
   &kAtcAllZoneEtc_UTC, // 0xd8e31abc, Etc/UTC
   &kAtcAllZoneAmerica_Yakutat, // 0xd8ee31e9, America/Yakutat
   &kAtcAllZoneAfrica_Algiers, // 0xd94515c1, Africa/Algiers
-  &kAtcAllZonePST8PDT, // 0xd99ee2dc, PST8PDT
   &kAtcAllZoneEurope_Simferopol, // 0xda9eb724, Europe/Simferopol
   &kAtcAllZoneAmerica_Matamoros, // 0xdd1b0259, America/Matamoros
   &kAtcAllZonePacific_Kanton, // 0xdd512f0e, Pacific/Kanton
@@ -410,10 +400,8 @@ const AtcZoneInfo * const kAtcAllZoneRegistry[351]  = {
   &kAtcAllZoneAmerica_Argentina_Tucuman, // 0xe96399eb, America/Argentina/Tucuman
   &kAtcAllZoneAsia_Magadan, // 0xebacc19b, Asia/Magadan
   &kAtcAllZoneAmerica_Ojinaga, // 0xebfde83f, America/Ojinaga
-  &kAtcAllZoneCST6CDT, // 0xf0e87d00, CST6CDT
   &kAtcAllZonePacific_Tahiti, // 0xf24c2446, Pacific/Tahiti
   &kAtcAllZonePacific_Tarawa, // 0xf2517e63, Pacific/Tarawa
-  &kAtcAllZoneMST7MDT, // 0xf2af9375, MST7MDT
   &kAtcAllZoneAsia_Tashkent, // 0xf3924254, Asia/Tashkent
   &kAtcAllZoneAsia_Sakhalin, // 0xf4a1c9bd, Asia/Sakhalin
   &kAtcAllZonePacific_Guadalcanal, // 0xf4dd25f0, Pacific/Guadalcanal
@@ -465,19 +453,19 @@ const AtcZoneInfo * const kAtcAllZoneAndLinkRegistry[596]  = {
   &kAtcAllZoneUS_Hawaii, // 0x09c8de2f, US/Hawaii -> Pacific/Honolulu
   &kAtcAllZoneAmerica_Boa_Vista, // 0x0a7b7efe, America/Boa_Vista
   &kAtcAllZoneAsia_Colombo, // 0x0af0e91d, Asia/Colombo
-  &kAtcAllZoneCET, // 0x0b87d921, CET
-  &kAtcAllZoneEET, // 0x0b87e1a3, EET
-  &kAtcAllZoneEST, // 0x0b87e371, EST
+  &kAtcAllZoneCET, // 0x0b87d921, CET -> Europe/Brussels
+  &kAtcAllZoneEET, // 0x0b87e1a3, EET -> Europe/Athens
+  &kAtcAllZoneEST, // 0x0b87e371, EST -> America/Panama
   &kAtcAllZoneGMT, // 0x0b87eb2d, GMT -> Etc/GMT
-  &kAtcAllZoneHST, // 0x0b87f034, HST
-  &kAtcAllZoneMET, // 0x0b8803ab, MET
-  &kAtcAllZoneMST, // 0x0b880579, MST
+  &kAtcAllZoneHST, // 0x0b87f034, HST -> Pacific/Honolulu
+  &kAtcAllZoneMET, // 0x0b8803ab, MET -> Europe/Brussels
+  &kAtcAllZoneMST, // 0x0b880579, MST -> America/Phoenix
   &kAtcAllZonePRC, // 0x0b88120a, PRC -> Asia/Shanghai
   &kAtcAllZoneROC, // 0x0b881a29, ROC -> Asia/Taipei
   &kAtcAllZoneROK, // 0x0b881a31, ROK -> Asia/Seoul
   &kAtcAllZoneUCT, // 0x0b882571, UCT -> Etc/UTC
   &kAtcAllZoneUTC, // 0x0b882791, UTC -> Etc/UTC
-  &kAtcAllZoneWET, // 0x0b882e35, WET
+  &kAtcAllZoneWET, // 0x0b882e35, WET -> Europe/Lisbon
   &kAtcAllZoneAmerica_Guatemala, // 0x0c8259f7, America/Guatemala
   &kAtcAllZoneEurope_Mariehamn, // 0x0caa6496, Europe/Mariehamn -> Europe/Helsinki
   &kAtcAllZoneAfrica_Monrovia, // 0x0ce90385, Africa/Monrovia
@@ -753,7 +741,7 @@ const AtcZoneInfo * const kAtcAllZoneAndLinkRegistry[596]  = {
   &kAtcAllZoneAustralia_LHI, // 0x8a973e17, Australia/LHI -> Australia/Lord_Howe
   &kAtcAllZoneAustralia_NSW, // 0x8a974812, Australia/NSW -> Australia/Sydney
   &kAtcAllZonePacific_Nauru, // 0x8acc41ae, Pacific/Nauru
-  &kAtcAllZoneEST5EDT, // 0x8adc72a3, EST5EDT
+  &kAtcAllZoneEST5EDT, // 0x8adc72a3, EST5EDT -> America/New_York
   &kAtcAllZonePacific_Palau, // 0x8af04a36, Pacific/Palau
   &kAtcAllZonePacific_Samoa, // 0x8b2699b4, Pacific/Samoa -> Pacific/Pago_Pago
   &kAtcAllZoneAmerica_Winnipeg, // 0x8c7dafc7, America/Winnipeg
@@ -775,7 +763,7 @@ const AtcZoneInfo * const kAtcAllZoneAndLinkRegistry[596]  = {
   &kAtcAllZoneAfrica_Niamey, // 0x914a30fd, Africa/Niamey -> Africa/Lagos
   &kAtcAllZoneAsia_Yerevan, // 0x9185c8cc, Asia/Yerevan
   &kAtcAllZoneAmerica_Detroit, // 0x925cfbc1, America/Detroit
-  &kAtcAllZoneAsia_Choibalsan, // 0x928aa4a6, Asia/Choibalsan
+  &kAtcAllZoneAsia_Choibalsan, // 0x928aa4a6, Asia/Choibalsan -> Asia/Ulaanbaatar
   &kAtcAllZoneAntarctica_Macquarie, // 0x92f47626, Antarctica/Macquarie
   &kAtcAllZoneAmerica_Belize, // 0x93256c81, America/Belize
   &kAtcAllZoneMexico_General, // 0x93711d57, Mexico/General -> America/Mexico_City
@@ -958,7 +946,7 @@ const AtcZoneInfo * const kAtcAllZoneAndLinkRegistry[596]  = {
   &kAtcAllZoneEtc_UTC, // 0xd8e31abc, Etc/UTC
   &kAtcAllZoneAmerica_Yakutat, // 0xd8ee31e9, America/Yakutat
   &kAtcAllZoneAfrica_Algiers, // 0xd94515c1, Africa/Algiers
-  &kAtcAllZonePST8PDT, // 0xd99ee2dc, PST8PDT
+  &kAtcAllZonePST8PDT, // 0xd99ee2dc, PST8PDT -> America/Los_Angeles
   &kAtcAllZoneEurope_Bratislava, // 0xda493bed, Europe/Bratislava -> Europe/Prague
   &kAtcAllZoneEurope_Simferopol, // 0xda9eb724, Europe/Simferopol
   &kAtcAllZonePacific_Funafuti, // 0xdb402d65, Pacific/Funafuti -> Pacific/Tarawa
@@ -1001,10 +989,10 @@ const AtcZoneInfo * const kAtcAllZoneAndLinkRegistry[596]  = {
   &kAtcAllZoneAsia_Magadan, // 0xebacc19b, Asia/Magadan
   &kAtcAllZoneAmerica_Ojinaga, // 0xebfde83f, America/Ojinaga
   &kAtcAllZonePacific_Saipan, // 0xeff7a35f, Pacific/Saipan -> Pacific/Guam
-  &kAtcAllZoneCST6CDT, // 0xf0e87d00, CST6CDT
+  &kAtcAllZoneCST6CDT, // 0xf0e87d00, CST6CDT -> America/Chicago
   &kAtcAllZonePacific_Tahiti, // 0xf24c2446, Pacific/Tahiti
   &kAtcAllZonePacific_Tarawa, // 0xf2517e63, Pacific/Tarawa
-  &kAtcAllZoneMST7MDT, // 0xf2af9375, MST7MDT
+  &kAtcAllZoneMST7MDT, // 0xf2af9375, MST7MDT -> America/Denver
   &kAtcAllZoneCanada_Eastern, // 0xf3612d5e, Canada/Eastern -> America/Toronto
   &kAtcAllZoneAsia_Tashkent, // 0xf3924254, Asia/Tashkent
   &kAtcAllZoneAsia_Sakhalin, // 0xf4a1c9bd, Asia/Sakhalin

--- a/src/zonedball/zone_registry.h
+++ b/src/zonedball/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedball/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedball
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -24,9 +24,9 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
-// Supported Zones: 596 (351 zones, 245 links)
+// Supported Zones: 596 (339 zones, 257 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
 //
 // Requested Years: [1800,2200]
@@ -41,37 +41,37 @@
 //
 // Records:
 //   Infos: 596
-//   Eras: 1963
+//   Eras: 1941
 //   Policies: 134
-//   Rules: 2234
+//   Rules: 2231
 //
 // Memory (8-bits):
 //   Context: 16
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 402
-//   Eras: 29445
-//   Zones: 4563
-//   Links: 3185
+//   Eras: 29115
+//   Zones: 4407
+//   Links: 3341
 //   Registry: 1192
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 160
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 75879
+//   TOTAL: 74967
 //
 // Memory (32-bits):
 //   Context: 24
-//   Rules: 26808
+//   Rules: 26772
 //   Policies: 1072
-//   Eras: 39260
-//   Zones: 8424
-//   Links: 5880
+//   Eras: 38820
+//   Zones: 8136
+//   Links: 6168
 //   Registry: 2384
-//   Formats: 1032
+//   Formats: 486
 //   Letters: 216
 //   Fragments: 0
 //   Names: 9076 (original: 9076)
-//   TOTAL: 94176
+//   TOTAL: 93154
 //
 // DO NOT EDIT
 
@@ -85,8 +85,8 @@ extern "C" {
 #endif
 
 // Zones
-#define kAtcAllZoneRegistrySize 351
-extern const AtcZoneInfo * const kAtcAllZoneRegistry[351];
+#define kAtcAllZoneRegistrySize 339
+extern const AtcZoneInfo * const kAtcAllZoneRegistry[339];
 
 // Zones and Links
 #define kAtcAllZoneAndLinkRegistrySize 596

--- a/src/zonedbtesting/Makefile
+++ b/src/zonedbtesting/Makefile
@@ -8,7 +8,7 @@ zone_registry.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2024a
+TZ_VERSION := 2024b
 START_YEAR := 2000 # unit tests assume start year 2000
 UNTIL_YEAR := 2200
 

--- a/src/zonedbtesting/zone_infos.c
+++ b/src/zonedbtesting/zone_infos.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (335 zones, 244 links)
+// Unsupported Zones: 579 (323 zones, 256 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]
@@ -54,11 +54,11 @@
 //   Zones: 208
 //   Links: 13
 //   Registry: 34
-//   Formats: 78
+//   Formats: 37
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3406
+//   TOTAL: 3365
 //
 // Memory (32-bits):
 //   Context: 24
@@ -68,11 +68,11 @@
 //   Zones: 384
 //   Links: 24
 //   Registry: 68
-//   Formats: 78
+//   Formats: 37
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3795
+//   TOTAL: 3754
 //
 // DO NOT EDIT
 
@@ -83,7 +83,7 @@
 // ZoneContext
 //---------------------------------------------------------------------------
 
-static const char kAtcTzDatabaseVersion[] = "2024a";
+static const char kAtcTzDatabaseVersion[] = "2024b";
 
 static const char * const kAtcFragments[] = {
 /*\x00*/ NULL,
@@ -123,10 +123,10 @@ const AtcZoneContext kAtcTestingZoneContext = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAfrica_Casablanca[]  = {
-  //              0:00    Morocco    +00/+01    2018 Oct 28  3:00
+  //              0:00    Morocco    %z    2018 Oct 28  3:00
   {
     &kAtcTestingZonePolicyMorocco /*zone_policy*/,
-    "+00/+01" /*format*/,
+    "" /*format*/,
     0 /*offset_code (0/15)*/,
     0 /*offset_remainder (0%15)*/,
     0 /*delta_minutes*/,
@@ -136,10 +136,10 @@ static const AtcZoneEra kAtcZoneEraAfrica_Casablanca[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              1:00    Morocco    +01/+00
+  //              1:00    Morocco    %z
   {
     &kAtcTestingZonePolicyMorocco /*zone_policy*/,
-    "+01/+00" /*format*/,
+    "" /*format*/,
     240 /*offset_code (3600/15)*/,
     0 /*offset_remainder (3600%15)*/,
     0 /*delta_minutes*/,
@@ -202,10 +202,10 @@ const AtcZoneInfo kAtcTestingZoneAfrica_Windhoek  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraAmerica_Caracas[]  = {
-  //             -4:00    -    -04    2007 Dec  9  3:00
+  //             -4:00    -    %z    2007 Dec  9  3:00
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -215,10 +215,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Caracas[]  = {
     720 /*until_time_code (10800/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:30    -    -0430    2016 May  1  2:30
+  //             -4:30    -    %z    2016 May  1  2:30
   {
     NULL /*zone_policy*/,
-    "-0430" /*format*/,
+    "" /*format*/,
     -1080 /*offset_code (-16200/15)*/,
     0 /*offset_remainder (-16200%15)*/,
     0 /*delta_minutes*/,
@@ -228,10 +228,10 @@ static const AtcZoneEra kAtcZoneEraAmerica_Caracas[]  = {
     600 /*until_time_code (9000/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //             -4:00    -    -04
+  //             -4:00    -    %z
   {
     NULL /*zone_policy*/,
-    "-04" /*format*/,
+    "" /*format*/,
     -960 /*offset_code (-14400/15)*/,
     0 /*offset_remainder (-14400%15)*/,
     0 /*delta_minutes*/,
@@ -683,10 +683,10 @@ const AtcZoneInfo kAtcTestingZoneEurope_Lisbon  = {
 //---------------------------------------------------------------------------
 
 static const AtcZoneEra kAtcZoneEraPacific_Apia[]  = {
-  //             -11:00    WS    -11/-10    2011 Dec 29 24:00
+  //             -11:00    WS    %z    2011 Dec 29 24:00
   {
     &kAtcTestingZonePolicyWS /*zone_policy*/,
-    "-11/-10" /*format*/,
+    "" /*format*/,
     -2640 /*offset_code (-39600/15)*/,
     0 /*offset_remainder (-39600%15)*/,
     0 /*delta_minutes*/,
@@ -696,10 +696,10 @@ static const AtcZoneEra kAtcZoneEraPacific_Apia[]  = {
     5760 /*until_time_code (86400/15)*/,
     0 /*until_time_modifier (kAtcSuffixW + seconds=0)*/,
   },
-  //              13:00    WS    +13/+14
+  //              13:00    WS    %z
   {
     &kAtcTestingZonePolicyWS /*zone_policy*/,
-    "+13/+14" /*format*/,
+    "" /*format*/,
     3120 /*offset_code (46800/15)*/,
     0 /*offset_remainder (46800%15)*/,
     0 /*delta_minutes*/,

--- a/src/zonedbtesting/zone_infos.h
+++ b/src/zonedbtesting/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (335 zones, 244 links)
+// Unsupported Zones: 579 (323 zones, 256 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]
@@ -54,11 +54,11 @@
 //   Zones: 208
 //   Links: 13
 //   Registry: 34
-//   Formats: 78
+//   Formats: 37
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3406
+//   TOTAL: 3365
 //
 // Memory (32-bits):
 //   Context: 24
@@ -68,11 +68,11 @@
 //   Zones: 384
 //   Links: 24
 //   Registry: 68
-//   Formats: 78
+//   Formats: 37
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3795
+//   TOTAL: 3754
 //
 // DO NOT EDIT
 
@@ -174,7 +174,7 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 
 
 //---------------------------------------------------------------------------
-// Unsupported zones: 335
+// Unsupported zones: 323
 //---------------------------------------------------------------------------
 
 // Africa/Abidjan {Zone missing from include list}
@@ -326,7 +326,6 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // Asia/Beirut {Zone missing from include list}
 // Asia/Bishkek {Zone missing from include list}
 // Asia/Chita {Zone missing from include list}
-// Asia/Choibalsan {Zone missing from include list}
 // Asia/Colombo {Zone missing from include list}
 // Asia/Damascus {Zone missing from include list}
 // Asia/Dhaka {Zone missing from include list}
@@ -405,11 +404,6 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // Australia/Melbourne {Zone missing from include list}
 // Australia/Perth {Zone missing from include list}
 // Australia/Sydney {Zone missing from include list}
-// CET {Zone missing from include list}
-// CST6CDT {Zone missing from include list}
-// EET {Zone missing from include list}
-// EST {Zone missing from include list}
-// EST5EDT {Zone missing from include list}
 // Etc/GMT {Zone missing from include list}
 // Etc/GMT+1 {Zone missing from include list}
 // Etc/GMT+10 {Zone missing from include list}
@@ -474,14 +468,9 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // Europe/Volgograd {Zone missing from include list}
 // Europe/Warsaw {Zone missing from include list}
 // Europe/Zurich {Zone missing from include list}
-// HST {Zone missing from include list}
 // Indian/Chagos {Zone missing from include list}
 // Indian/Maldives {Zone missing from include list}
 // Indian/Mauritius {Zone missing from include list}
-// MET {Zone missing from include list}
-// MST {Zone missing from include list}
-// MST7MDT {Zone missing from include list}
-// PST8PDT {Zone missing from include list}
 // Pacific/Auckland {Zone missing from include list}
 // Pacific/Bougainville {Zone missing from include list}
 // Pacific/Chatham {Zone missing from include list}
@@ -511,14 +500,14 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // Pacific/Tahiti {Zone missing from include list}
 // Pacific/Tarawa {Zone missing from include list}
 // Pacific/Tongatapu {Zone missing from include list}
-// WET {Zone missing from include list}
 
 
 //---------------------------------------------------------------------------
-// Notable zones: 0
+// Notable zones: 2
 //---------------------------------------------------------------------------
 
 // Africa/Casablanca {
+//   RULES not fixed but FORMAT is missing '%s' or '/',
 //   Morocco {SAVE '-1:00' is a negative DST}
 // }
 // Africa/Windhoek {
@@ -528,10 +517,11 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 //     SAVE '-1:00' is a negative DST,
 //   }
 // }
+// Pacific/Apia {RULES not fixed but FORMAT is missing '%s' or '/'}
 
 
 //---------------------------------------------------------------------------
-// Unsupported links: 244
+// Unsupported links: 256
 //---------------------------------------------------------------------------
 
 // Africa/Accra {Link missing from include list}
@@ -627,6 +617,7 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // Asia/Bahrain {Link missing from include list}
 // Asia/Brunei {Link missing from include list}
 // Asia/Calcutta {Link missing from include list}
+// Asia/Choibalsan {Link missing from include list}
 // Asia/Chongqing {Link missing from include list}
 // Asia/Chungking {Link missing from include list}
 // Asia/Dacca {Link missing from include list}
@@ -666,6 +657,8 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // Brazil/DeNoronha {Link missing from include list}
 // Brazil/East {Link missing from include list}
 // Brazil/West {Link missing from include list}
+// CET {Link missing from include list}
+// CST6CDT {Link missing from include list}
 // Canada/Atlantic {Link missing from include list}
 // Canada/Central {Link missing from include list}
 // Canada/Eastern {Link missing from include list}
@@ -677,6 +670,9 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // Chile/Continental {Link missing from include list}
 // Chile/EasterIsland {Link missing from include list}
 // Cuba {Link missing from include list}
+// EET {Link missing from include list}
+// EST {Link missing from include list}
+// EST5EDT {Link missing from include list}
 // Egypt {Link missing from include list}
 // Eire {Link missing from include list}
 // Etc/GMT+0 {Link missing from include list}
@@ -719,6 +715,7 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // GMT-0 {Link missing from include list}
 // GMT0 {Link missing from include list}
 // Greenwich {Link missing from include list}
+// HST {Link missing from include list}
 // Hongkong {Link missing from include list}
 // Iceland {Link missing from include list}
 // Indian/Antananarivo {Link missing from include list}
@@ -735,6 +732,9 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // Japan {Link missing from include list}
 // Kwajalein {Link missing from include list}
 // Libya {Link missing from include list}
+// MET {Link missing from include list}
+// MST {Link missing from include list}
+// MST7MDT {Link missing from include list}
 // Mexico/BajaNorte {Link missing from include list}
 // Mexico/BajaSur {Link missing from include list}
 // Mexico/General {Link missing from include list}
@@ -742,6 +742,7 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // NZ-CHAT {Link missing from include list}
 // Navajo {Link missing from include list}
 // PRC {Link missing from include list}
+// PST8PDT {Link missing from include list}
 // Pacific/Chuuk {Link missing from include list}
 // Pacific/Enderbury {Link missing from include list}
 // Pacific/Funafuti {Link missing from include list}
@@ -777,6 +778,7 @@ extern const AtcZoneInfo kAtcTestingZoneUS_Pacific; // US/Pacific -> America/Los
 // UTC {Link missing from include list}
 // Universal {Link missing from include list}
 // W-SU {Link missing from include list}
+// WET {Link missing from include list}
 // Zulu {Link missing from include list}
 
 

--- a/src/zonedbtesting/zone_policies.c
+++ b/src/zonedbtesting/zone_policies.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (335 zones, 244 links)
+// Unsupported Zones: 579 (323 zones, 256 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]
@@ -54,11 +54,11 @@
 //   Zones: 208
 //   Links: 13
 //   Registry: 34
-//   Formats: 78
+//   Formats: 37
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3406
+//   TOTAL: 3365
 //
 // Memory (32-bits):
 //   Context: 24
@@ -68,11 +68,11 @@
 //   Zones: 384
 //   Links: 24
 //   Registry: 68
-//   Formats: 78
+//   Formats: 37
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3795
+//   TOTAL: 3754
 //
 // DO NOT EDIT
 

--- a/src/zonedbtesting/zone_policies.h
+++ b/src/zonedbtesting/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (335 zones, 244 links)
+// Unsupported Zones: 579 (323 zones, 256 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]
@@ -54,11 +54,11 @@
 //   Zones: 208
 //   Links: 13
 //   Registry: 34
-//   Formats: 78
+//   Formats: 37
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3406
+//   TOTAL: 3365
 //
 // Memory (32-bits):
 //   Context: 24
@@ -68,11 +68,11 @@
 //   Zones: 384
 //   Links: 24
 //   Registry: 68
-//   Formats: 78
+//   Formats: 37
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3795
+//   TOTAL: 3754
 //
 // DO NOT EDIT
 

--- a/src/zonedbtesting/zone_registry.c
+++ b/src/zonedbtesting/zone_registry.c
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (335 zones, 244 links)
+// Unsupported Zones: 579 (323 zones, 256 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]
@@ -54,11 +54,11 @@
 //   Zones: 208
 //   Links: 13
 //   Registry: 34
-//   Formats: 78
+//   Formats: 37
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3406
+//   TOTAL: 3365
 //
 // Memory (32-bits):
 //   Context: 24
@@ -68,11 +68,11 @@
 //   Zones: 384
 //   Links: 24
 //   Registry: 68
-//   Formats: 78
+//   Formats: 37
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3795
+//   TOTAL: 3754
 //
 // DO NOT EDIT
 

--- a/src/zonedbtesting/zone_registry.h
+++ b/src/zonedbtesting/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/acetimec/src/zonedbtesting/tzfiles
 //     --output_dir /home/brian/src/acetimec/src/zonedbtesting
-//     --tz_version 2024a
+//     --tz_version 2024b
 //     --actions zonedb
 //     --languages c
 //     --scope complete
@@ -25,10 +25,10 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2024a
+// from https://github.com/eggert/tz/releases/tag/2024b
 //
 // Supported Zones: 17 (16 zones, 1 links)
-// Unsupported Zones: 579 (335 zones, 244 links)
+// Unsupported Zones: 579 (323 zones, 256 links)
 //
 // Requested Years: [2000,2200]
 // Accurate Years: [2000,32767]
@@ -54,11 +54,11 @@
 //   Zones: 208
 //   Links: 13
 //   Registry: 34
-//   Formats: 78
+//   Formats: 37
 //   Letters: 23
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3406
+//   TOTAL: 3365
 //
 // Memory (32-bits):
 //   Context: 24
@@ -68,11 +68,11 @@
 //   Zones: 384
 //   Links: 24
 //   Registry: 68
-//   Formats: 78
+//   Formats: 37
 //   Letters: 33
 //   Fragments: 0
 //   Names: 268 (original: 268)
-//   TOTAL: 3795
+//   TOTAL: 3754
 //
 // DO NOT EDIT
 

--- a/src/zoneinfo/zone_info.h
+++ b/src/zoneinfo/zone_info.h
@@ -260,17 +260,14 @@ typedef struct AtcZoneEra {
 
   /**
    * Zone abbreviations (e.g. PST, EST) determined by the FORMAT column. It has
-   * 3 encodings in the TZ DB files:
+   * 4 encodings in the TZ DB files:
    *
    *  1) A fixed string, e.g. "GMT".
    *  2) Two strings separated by a '/', e.g. "-03/-02" indicating
    *     "{std}/{dst}" options.
    *  3) A single string with a substitution, e.g. "E%sT", where the "%s" is
    *  replaced by the LETTER value from the ZoneRule.
-   *
-   * BasicZoneProcessor supports only a single letter subsitution from LETTER,
-   * but ExtendedZoneProcessor supports substituting multi-character strings
-   * (e.g. "CAT", "DD", "+00").
+   *  4) An empty string which represents the format string of "%z".
    *
    * The TZ DB files use '%s' to indicate the substitution, but for simplicity,
    * AceTime replaces the "%s" with just a '%' character with no loss of

--- a/tests/common_test.c
+++ b/tests/common_test.c
@@ -40,6 +40,33 @@ ACU_TEST(test_atc_djb2)
 
 //---------------------------------------------------------------------------
 
+ACU_TEST(test_atc_seconds_to_hms)
+{
+  uint16_t hh, mm, ss;
+
+  atc_seconds_to_hms(0, &hh, &mm, &ss);
+  ACU_ASSERT((uint16_t) 0 == hh);
+  ACU_ASSERT((uint16_t) 0 == mm);
+  ACU_ASSERT((uint16_t) 0 == ss);
+
+  atc_seconds_to_hms(3600, &hh, &mm, &ss);
+  ACU_ASSERT((uint16_t) 1 == hh);
+  ACU_ASSERT((uint16_t) 0 == mm);
+  ACU_ASSERT((uint16_t) 0 == ss);
+
+  atc_seconds_to_hms(3720, &hh, &mm, &ss);
+  ACU_ASSERT((uint16_t) 1 == hh);
+  ACU_ASSERT((uint16_t) 2 == mm);
+  ACU_ASSERT((uint16_t) 0 == ss);
+
+  atc_seconds_to_hms(3723, &hh, &mm, &ss);
+  ACU_ASSERT((uint16_t) 1 == hh);
+  ACU_ASSERT((uint16_t) 2 == mm);
+  ACU_ASSERT((uint16_t) 3 == ss);
+}
+
+//---------------------------------------------------------------------------
+
 ACU_CONTEXT();
 
 int main()
@@ -47,5 +74,6 @@ int main()
   ACU_RUN_TEST(test_atc_copy_replace_string_normal);
   ACU_RUN_TEST(test_atc_copy_replace_string_out_of_bounds);
   ACU_RUN_TEST(test_atc_djb2);
+  ACU_RUN_TEST(test_atc_seconds_to_hms);
   ACU_SUMMARY();
 }

--- a/tests/zonedb_test.c
+++ b/tests/zonedb_test.c
@@ -11,15 +11,15 @@
 
 ACU_TEST(test_zonedb_sizes)
 {
-  // These numbers are correct for TZDB 2023d
-  ACU_ASSERT(sizeof(kAtcZoneRegistry) / sizeof(AtcZoneInfo*) == 351);
+  // These numbers are correct for TZDB 2024b
+  ACU_ASSERT(sizeof(kAtcZoneRegistry) / sizeof(AtcZoneInfo*) == 339);
   ACU_ASSERT(sizeof(kAtcZoneAndLinkRegistry) / sizeof(AtcZoneInfo*) == 596);
 }
 
 ACU_TEST(test_zonedball_sizes)
 {
-  // These numbers are correct for TZDB 2023d
-  ACU_ASSERT(sizeof(kAtcAllZoneRegistry) / sizeof(AtcZoneInfo*) == 351);
+  // These numbers are correct for TZDB 2024b
+  ACU_ASSERT(sizeof(kAtcAllZoneRegistry) / sizeof(AtcZoneInfo*) == 339);
   ACU_ASSERT(sizeof(kAtcAllZoneAndLinkRegistry) / sizeof(AtcZoneInfo*) == 596);
 }
 


### PR DESCRIPTION
- 0.12.0 (2024-12-14, TZDB 2024b)
    - Support new `%z` value in FORMAT column.
    - Upgrade TZDB to 2024b
        - https://lists.iana.org/hyperkitty/list/tz-announce@iana.org/thread/IZ7AO6WRE3W3TWBL5IR6PMQUL433BQIE/
        - "Improve historical data for Mexico, Mongolia, and Portugal. System V
          names are now obsolescent. The main data form now uses %z. The code
          now conforms to RFC 8536 for early timestamps. Support POSIX.1-2024,
          which removes asctime_r and ctime_r. Assume POSIX.2-1992 or later for
          shell scripts. SUPPORT_C89 now defaults to 1."
