### PR TITLE
merge 0.15.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 - unreleased
+- 0.15.0 (2025-11-17, TZDB 2025b)
+    - **Breaking** Replace `AtcZonedExtra.fold_type` with
+      `AtcZonedExtra.resolved` which is identical to
+      `AtcZonedDateTime.resolved`.
 - 0.14.0 (2025-10-21, TZDB 2025b)
     - Graduate to Beta-level, API should be mostly stable
     - **Breaking** Rename LocalXxx to PlainXxx, following the conventions

--- a/README.md
+++ b/README.md
@@ -781,13 +781,13 @@ be handled. The resulting `zdt.resolved` field is available to indicate how the
 ambiguity (if any) was resolved:
 
 - `kAtcResolvedUnique`: AtcPlainDateTime was unique
-- `kAtcResolvedOverlapEarlier: AtcPlainDateTime matched an overlap and was
+- `kAtcResolvedOverlapEarlier`: AtcPlainDateTime matched an overlap and was
     resolved to the earlier datetime
-- `kAtcResolvedOverlapLater: AtcPlainDateTime matched an overlap and was
+- `kAtcResolvedOverlapLater`: AtcPlainDateTime matched an overlap and was
     resolved to the later datetime
-- `kAtcResolvedGapEarlier: AtcPlainDateTime matched a gap and was resolved to
+- `kAtcResolvedGapEarlier`: AtcPlainDateTime matched a gap and was resolved to
     the earlier datetime
-- `kAtcResolvedGapLater: AtcPlainDateTime matched a gap and was resolved to the
+- `kAtcResolvedGapLater`: AtcPlainDateTime matched a gap and was resolved to the
     later datetime
 
 The `disambiguate` parameter is *not* required for the

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ Unix epoch of 1970, but is set to 2050 by default. This allows the upper limit
 of this library to be the year 2118. In addition, the epoch year is configurable
 at *run-time* to any year from about 0001 to 9999.
 
+The library does *not* support [leap
+seconds](https://en.wikipedia.org/wiki/Leap_second) and ignores them. Instead it
+uses [UNIX time](https://en.wikipedia.org/wiki/Unix_time) (aka POSIX time) where
+the *POSIX second* is variable in duration compared to the [SI
+second](https://en.wikipedia.org/wiki/Second). During a leap second, a POSIX
+second is conceptually equal to 2 SI seconds, and the POSIX clock changes from
+`23:59:58` to `23:59:59`, then is held for 2 seconds before rolling over to
+`00:00:00`. Most real-time clock (RTC) chips do not support leap seconds either,
+so the final `23:59:59` second will be held for only one second instead of two,
+so a clock using acetimec with such an RTC chip will be off by one second after
+a leap second compared to the atomic UTC clock.
+
 The acetimec library does not perform any dynamic allocation of memory
 internally. Everything it needs is allocated statically or provided by the
 calling program. Applications can choose to allocate the necessary resources
@@ -41,7 +53,7 @@ mostly because the C language does not provide the same level of abstraction and
 encapsulation as the C++ language. If the equivalent functionality of AceTime
 was attempted in this library, the public API would become too large and
 complex, with diminishing returns from the increased complexity. Specifically,
-this library implements the only algorithms provided by the
+this library implements only the algorithms provided by the
 `ExtendedZoneProcessor` class of the AceTime library. It does not implement the
 functionality provided by the `BasicZoneProcessor` of the AceTime library.
 
@@ -1054,9 +1066,9 @@ parameter extends the invalid time backwards or forwards away from the gap. We
 need 2 different sets of offset seconds:
 
 - `req_std_offset_seconds` and `req_dst_offset_seconds` fields correspond
-  to the `AtcPlainDateTime` *before- normalization, and
+  to the `AtcPlainDateTime` *before* normalization, and
 - `std_offset_seconds` and `dst_offset_seconds` fields correspond to the
-  `AtcPlainDateTime` *after- normalization.
+  `AtcPlainDateTime` *after* normalization.
 
 There following functions operate on this data structure (analogous to the
 functions that work with the `AtcZonedDateTime` data structure):
@@ -1336,6 +1348,7 @@ The following 3rd party libraries were found to be non-conformant with
       mutable.
     - If the library is used in a multi-threaded environment, thread-safety must
       be provided externally.
+- No support for [leap seconds](https://en.wikipedia.org/wiki/Leap_second).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ functionality provided by the `BasicZoneProcessor` of the AceTime library.
     - [AtcZonedExtra](#atczonedextra)
     - [AtcZoneRegistrar](#atczoneregistrar)
     - [Custom Registry](#custom-registry)
-- [Bugs and Limitations](#bugs-and-limitations)
+- [Validation](#validation)
+- [Bugs And Limitations](#bugs-and-limitations)
 - [License](#license)
 - [Feedback and Support](#feedback-and-support)
 - [Authors](#authors)
@@ -1248,6 +1249,53 @@ void setup()
 
 See [examples/hello_custom_registry](examples/hello_custom_registry) for
 an example of a custom registry.
+
+## Validation
+
+Validation of the `acetimec` library involves validating the algorithms in the
+[src/acetimec](src/acetimec) directory and the various zoneinfo
+databases over their respective year range of validity:
+
+- [zonedb2000](src/zonedb2000/): from year 2000 until 2200
+- [zonedb2025](src/zonedb2025/): from year 2025 until 2200
+- [zonedball](src/zonedball/)): from year 1800 until 2200 (the earliest date in
+  TZDB is 1844)
+
+For each `zonedb*` database, the DST transitions, epochseconds, and timezone
+abbreviations were calculated using `acetimec` over the year range of validity,
+and compared against the same information generated from the following
+first-party and third-party libraries:
+
+- [C++11/14/17 Hinnant date](https://github.com/HowardHinnant/date) library
+- [GNU libc time](https://www.gnu.org/software/libc/libc.html) library
+- [C# Noda Time](https://nodatime.org) library
+- [Python whenever](https://pypi.org/project/whenever/)
+- [AceTime](https://github.com/bxparks/AceTime): Arduino C++ version of AceTime
+- [acetimego](https://github.com/bxparks/acetimego): Go or TinyGo version of
+  AceTime
+- [acetimepy](https://github.com/bxparks/acetimepy): Python version of AceTime
+
+The results from `acetimec` library were identical to the above libraries, which
+gives a solid indication that the code and zone databases of `acetimec` are
+correct.
+
+The following 3rd party libraries were found to be non-conformant with
+`acetimec` for various reasons:
+
+- [Python pytz](https://pypi.org/project/pytz/): pytz cannot handle years after
+  2038
+- [Python dateutil](https://pypi.org/project/python-dateutil/): dateutil cannot
+  handle years after 2038
+- [Python 3.9 zoneinfo](https://docs.python.org/3/library/zoneinfo.html): 31
+  zones produce incorrect DST offsets
+- Java JDK 11
+  [java.time](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/package-summary.html)
+  library from year 1800 until 2200
+    * 3 IANA timezones are missing from `java.time`
+    * ~100 zones seem to produce incorrect DST offsets
+    * ~7 zones seem to produce incorrect epochSeconds
+- [Go lang `time` package](https://pkg.go.dev/time): 23 zones produce incorrect
+  results
 
 ## Bugs And Limitations
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ this library implements only the algorithms provided by the
 functionality provided by the `BasicZoneProcessor` of the AceTime library.
 
 **Status**: Beta-level, API mostly stable \
-**Version**: 0.14.0 (2025-10-21, TZDB 2025b) \
+**Version**: 0.15.0 (2025-11-17, TZDB 2025b) \
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 
 ## Table of Contents
@@ -337,13 +337,6 @@ A number of public constants are provided by this library:
 - `kAtcResolvedOverlapLater = 2`: in overlap and resolved to later time.
 - `kAtcResolvedGapEarlier = 3`: in gap and resolved to earlier time
 - `kAtcResolvedGapLater = 4`: in gap and resolved to later time
-
-**AtcZonedExtra fold_type**
-
-- `kAtcFoldTypeNotFound = 0`: AtcZonedExtra was not found (should never happen)
-- `kAtcFoldTypeExact = 1`: the PlainDateTime or epoch seconds was unique
-- `kAtcFoldTypeOverlap = 2`: the PlainDateTime was in an overlap
-- `kAtcFoldTypeGap = 3`: the PlainDateTime was in a gap
 
 ### `atc_time_t`
 
@@ -1040,15 +1033,8 @@ overlap. But most users will probably be satisfied by the information provided
 by the `AtcZonedDateTime.resolved` field.
 
 ```C
-enum {
-  kAtcFoldTypeNotFound = 0,
-  kAtcFoldTypeExact = 1,
-  kAtcFoldTypeGap = 2,
-  kAtcFoldTypeOverlap = 3,
-};
-
 typedef struct AtcZonedExtra {
-  int8_t fold_type;
+  uint8_t resolved;
   char abbrev[kAtcAbbrevSize];
   int32_t std_offset_seconds; // STD offset
   int32_t dst_offset_seconds; // DST offset
@@ -1057,13 +1043,15 @@ typedef struct AtcZonedExtra {
 } AtcZonedExtra;
 ```
 
-For `type` of `kAtcFoldTypeExact` and `kAtcFoldTypeOverlap`, the `req_std_offset_seconds` and `req_dst_offset_seconds` will be identical
-to the corresponding `std_offset_seconds` and `dst_offset_seconds` parameters.
+For `type` of `kAtcResolvedUnique`, `kAtcResolvedOverlapEarlier`, and
+`kAtcResolvedOverlapLater`, the `req_std_offset_seconds` and
+`req_dst_offset_seconds` will be identical to the corresponding
+`std_offset_seconds` and `dst_offset_seconds` parameters.
 
-For `type` `kAtcFoldTypeGap`, which can be returned only by the
-`atc_zoned_extra_from_plain_date_time()` function below, the `disambiguate`
-parameter extends the invalid time backwards or forwards away from the gap. We
-need 2 different sets of offset seconds:
+For `type` `kAtcResolvedGapEarlier` and `kAtcResolvedGapLater`, which can be
+returned only by the `atc_zoned_extra_from_plain_date_time()` function below,
+the `disambiguate` parameter extends the invalid time backwards or forwards away
+from the gap. We need 2 different sets of offset seconds:
 
 - `req_std_offset_seconds` and `req_dst_offset_seconds` fields correspond
   to the `AtcPlainDateTime` *before* normalization, and
@@ -1095,7 +1083,7 @@ void atc_zoned_extra_from_plain_date_time(
     uint8_t disambiguate);
 ```
 
-On error, the `extra.fold_type` field is set to `kAtcFoldTypeNotFound` and
+On error, the `extra.resolved` field is set to `kAtcResolvedError` and
 `atc_zoned_extra_is_error()` returns `true`.
 
 See [examples/hello_zonedextra](examples/hello_zonedextra) for an example of

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,23 @@
 # Documentation
 
-These [Doxygen docs](https://bxparks.github.io/acetimec/html/) are
-viewable on GitHub Pages.
+The main [README.md](../README.md) contains the majority of the documentation.
+
+This directory contains scripts to generate [doxygen](https://www.doxygen.nl/)
+documentation from the embedded docstrings in the code.
+
+First, install doxygen and GNU Make if you don't already have them, with
+something like the following on an Ubuntu Linux machine:
+
+```
+$ sudo apt install doxygen make
+```
+
+Second, run the `make` command to generate the HTML files under the `html`
+directory:
+
+```
+$ cd docs
+$ make
+```
+
+Third, open the `./docs/html/index.html` file in your web browser.

--- a/docs/doxygen.cfg
+++ b/docs/doxygen.cfg
@@ -38,7 +38,7 @@ PROJECT_NAME           = acetimec
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.14.0
+PROJECT_NUMBER         = 0.15.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/doxygen.cfg
+++ b/docs/doxygen.cfg
@@ -38,7 +38,7 @@ PROJECT_NAME           = acetimec
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.11.0
+PROJECT_NUMBER         = 0.14.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/examples/hello_zonedextra/hello_zonedextra.c
+++ b/examples/hello_zonedextra/hello_zonedextra.c
@@ -7,29 +7,29 @@ $ make
 $ ./hello_zonedextra.out
 ==== Before gap at 2022-03-13 00:30:00
 ZonedDateTime: 2022-03-13T00:30:00-08:00[America/Los_Angeles]
-ZonedDateTime.resolved: 0
+ZonedDateTime.resolved: 1
 ZonedExtra.abbrev: PST
-ZonedExtra.fold_type: 1
+ZonedExtra.resolved: 1
 ==== Inside gap at 2022-03-13 02:30:00
 ZonedDateTime: 2022-03-13T03:30:00-07:00[America/Los_Angeles]
-ZonedDateTime.resolved: 4
+ZonedDateTime.resolved: 5
 ZonedExtra.abbrev: PDT
-ZonedExtra.fold_type: 3
+ZonedExtra.resolved: 5
 ==== In Daylight time at 2022-03-13 03:30:00
 ZonedDateTime: 2022-03-13T03:30:00-07:00[America/Los_Angeles]
-ZonedDateTime.resolved: 0
-ZonedExtra.abbrev: PDT
-ZonedExtra.fold_type: 1
-==== In overlap at 2022-11-06 01:30:00
-ZonedDateTime: 2022-11-06T01:30:00-07:00[America/Los_Angeles]
 ZonedDateTime.resolved: 1
 ZonedExtra.abbrev: PDT
-ZonedExtra.fold_type: 2
+ZonedExtra.resolved: 1
+==== In overlap at 2022-11-06 01:30:00
+ZonedDateTime: 2022-11-06T01:30:00-07:00[America/Los_Angeles]
+ZonedDateTime.resolved: 2
+ZonedExtra.abbrev: PDT
+ZonedExtra.resolved: 2
 ==== In Standard time at 2022-11-06 02:30:00
 ZonedDateTime: 2022-11-06T02:30:00-08:00[America/Los_Angeles]
-ZonedDateTime.resolved: 0
+ZonedDateTime.resolved: 1
 ZonedExtra.abbrev: PST
-ZonedExtra.fold_type: 1
+ZonedExtra.resolved: 1
 */
 
 #include <stdlib.h> // exit()
@@ -77,7 +77,7 @@ void print_info(const char *label, AtcPlainDateTime *pdt, AtcTimeZone *tz)
 
   // Print the abbreviation and fold type (exact, overlap, gap).
   printf("ZonedExtra.abbrev: %s\n", extra.abbrev);
-  printf("ZonedExtra.fold_type: %d\n", extra.fold_type);
+  printf("ZonedExtra.resolved: %d\n", extra.resolved);
 }
 
 void print_dates()

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=acetimec
-version=3.0.0
+version=0.14.0
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=Date, time, timezone library using the C language

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=acetimec
-version=0.14.0
+version=0.15.0
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=Date, time, timezone library using the C language

--- a/src/acetimec.h
+++ b/src/acetimec.h
@@ -7,8 +7,8 @@
 #define ACE_TIME_C_H
 
 /* Version format: xxyyzz == "xx.yy.zz" */
-#define ACE_TIME_C_VERSION 1400
-#define ACE_TIME_C_VERSION_STRING "0.14.0"
+#define ACE_TIME_C_VERSION 1500
+#define ACE_TIME_C_VERSION_STRING "0.15.0"
 
 #include "zoneinfo/zone_info.h"
 #include "zoneinfo/zone_info_utils.h"

--- a/src/acetimec/common.h
+++ b/src/acetimec/common.h
@@ -98,20 +98,23 @@ enum {
 };
 
 enum {
-  /** Resolved to unique ZonedDateTime. */
-  kAtcResolvedUnique = 0,
+  /** Resolved to an error, for example, was not found. */
+  kAtcResolvedError = 0,
+
+  /** Resolved to unique ZonedDateTime or ZonedExtra. */
+  kAtcResolvedUnique = 1,
 
   /** In overlap and resolved to earlier time. */
-  kAtcResolvedOverlapEarlier = 1,
+  kAtcResolvedOverlapEarlier = 2,
 
   /** In overlap and resolved to later time. */
-  kAtcResolvedOverlapLater = 2,
+  kAtcResolvedOverlapLater = 3,
 
   /** In gap and resolved to earlier time. */
-  kAtcResolvedGapEarlier = 3,
+  kAtcResolvedGapEarlier = 4,
 
   /** In gap and resolved to later time. */
-  kAtcResolvedGapLater = 4,
+  kAtcResolvedGapLater = 5,
 };
 
 enum {

--- a/src/acetimec/time_zone.c
+++ b/src/acetimec/time_zone.c
@@ -127,11 +127,12 @@ void atc_time_zone_zoned_extra_from_epoch_seconds(
     AtcFindResult result;
     atc_processor_find_by_epoch_seconds(
         tz->zone_processor, epoch_seconds, &result);
-    extra->fold_type = result.type;
     if (result.type == kAtcFindResultNotFound) {
+      atc_zoned_extra_set_error(extra);
       return;
     }
 
+    extra->resolved = kAtcResolvedUnique;
     extra->std_offset_seconds = result.std_offset_seconds;
     extra->dst_offset_seconds = result.dst_offset_seconds;
     extra->req_std_offset_seconds = result.req_std_offset_seconds;
@@ -139,7 +140,7 @@ void atc_time_zone_zoned_extra_from_epoch_seconds(
     memcpy(extra->abbrev, result.abbrev, kAtcAbbrevSize);
     extra->abbrev[kAtcAbbrevSize - 1] = '\0';
   } else {
-    extra->fold_type = kAtcFindResultExact;
+    extra->resolved = kAtcResolvedUnique;
     extra->std_offset_seconds = 0;
     extra->dst_offset_seconds = 0;
     extra->req_std_offset_seconds = 0;
@@ -167,11 +168,13 @@ void atc_time_zone_zoned_extra_from_plain_date_time(
     AtcFindResult result;
     atc_processor_find_by_plain_date_time(
       tz->zone_processor, pdt, disambiguate, &result);
-    extra->fold_type = result.type;
     if (result.type == kAtcFindResultNotFound) {
+      atc_zoned_extra_set_error(extra);
       return;
     }
 
+    extra->resolved = resolve_for_result_type_and_fold(
+        result.type, result.fold);
     extra->std_offset_seconds = result.std_offset_seconds;
     extra->dst_offset_seconds = result.dst_offset_seconds;
     extra->req_std_offset_seconds = result.req_std_offset_seconds;
@@ -179,7 +182,7 @@ void atc_time_zone_zoned_extra_from_plain_date_time(
     memcpy(extra->abbrev, result.abbrev, kAtcAbbrevSize);
     extra->abbrev[kAtcAbbrevSize - 1] = '\0';
   } else {
-    extra->fold_type = kAtcFindResultExact;
+    extra->resolved = kAtcResolvedUnique;
     extra->std_offset_seconds = 0;
     extra->dst_offset_seconds = 0;
     extra->req_std_offset_seconds = 0;

--- a/src/acetimec/zone_processor.h
+++ b/src/acetimec/zone_processor.h
@@ -132,10 +132,7 @@ typedef struct AtcZoneProcessor {
   AtcTransitionStorage transition_storage;
 } AtcZoneProcessor;
 
-/**
- * Values of the the AtcFindResult.type field. Must be identical to the
- * corresponding kAtcFoldTypeXxx in zoned_extra.h.
- */
+/** Values of the the AtcFindResult.type field. */
 enum {
   kAtcFindResultNotFound = 0,
   kAtcFindResultExact = 1,

--- a/src/acetimec/zoned_extra.c
+++ b/src/acetimec/zoned_extra.c
@@ -9,12 +9,12 @@
 
 void atc_zoned_extra_set_error(AtcZonedExtra *extra)
 {
-  extra->fold_type = kAtcFoldTypeNotFound;
+  extra->resolved = kAtcResolvedError;
 }
 
 bool atc_zoned_extra_is_error(const AtcZonedExtra *extra)
 {
-  return extra->fold_type == kAtcFoldTypeNotFound;
+  return extra->resolved == kAtcResolvedError;
 }
 
 void atc_zoned_extra_from_epoch_seconds(

--- a/src/acetimec/zoned_extra.h
+++ b/src/acetimec/zoned_extra.h
@@ -27,25 +27,16 @@ typedef struct AtcTimeZone AtcTimeZone;
 typedef struct AtcPlainDateTime AtcPlainDateTime;
 
 /**
- * Values of the the AtcZonedExtra.fold_type field. Must be identical to the
- * corresponding AtcFindResultXxx enums in zone_processor.h.
- */
-enum {
-  kAtcFoldTypeNotFound = 0, // rename this to kAtcFoldTypeError?
-  kAtcFoldTypeExact = 1,
-  kAtcFoldTypeOverlap = 2,
-  kAtcFoldTypeGap = 3,
-};
-
-/**
  * Extra information about a given time zone at a specified epoch seconds.
  */
 typedef struct AtcZonedExtra {
   /**
-   * Result of search for the PlainDateTime or epoch_seconds, which is
-   * determines by the type of fold.
+   * Describes how the lookup from PlainDateTime or epoch_seconds was resolved,
+   * as determined by the type of fold and the disambiguate parameter. This
+   * parameter is identical to the AtcZonedDatetime.resolved field. The values
+   * are defined by the kAtcResolvedXxx constants.
    */
-  int8_t fold_type;
+  uint8_t resolved;
 
   /** abbreviation (e.g. PST, PDT) */
   char abbrev[kAtcAbbrevSize];
@@ -64,19 +55,20 @@ typedef struct AtcZonedExtra {
 } AtcZonedExtra;
 
 /**
- * Set the given AtcZonedDateTime to its error state, i.e. kFoldTypeNotFound.
+ * Set the given AtcZonedExtra to its error state, AtcZonedExtra.resolved ==
+ * kAtcResolvedError.
  */
 void atc_zoned_extra_set_error(AtcZonedExtra *extra);
 
 /**
- * Return true if AtcZonedExtra is an error defined by fold_type ==
- * kFoldTypeNotFound.
+ * Return true if AtcZonedExtra is an error indicated by (resolved ==
+ * kResolvedError).
  */
 bool atc_zoned_extra_is_error(const AtcZonedExtra *extra);
 
 /**
  * Extract the extra zone information at given epoch seconds.
- * Returns error status in `extra->fold_type`.
+ * Returns error status in `extra->resolved`.
  */
 void atc_zoned_extra_from_epoch_seconds(
     AtcZonedExtra *extra,
@@ -89,7 +81,7 @@ void atc_zoned_extra_from_epoch_seconds(
  * seconds is determined by the range of the epoch seconds in the context of the
  * current epoch year.
  *
- * Returns `extra->fold_type == kAtcFoldTypeNotFound` if not found.
+ * Returns `extra->resolved == kAtcResolvedError` if not found.
  */
 void atc_zoned_extra_from_unix_seconds(
     AtcZonedExtra *extra,
@@ -98,7 +90,7 @@ void atc_zoned_extra_from_unix_seconds(
 
 /**
  * Extract the extra zone information at given PlainDateTime.
- * Returns `extra->fold_type == kAtcFoldTypeNotFound` if not found.
+ * Returns `extra->resolved == kAtcResolvedError` if not found.
  */
 void atc_zoned_extra_from_plain_date_time(
     AtcZonedExtra *extra,

--- a/tests/time_zone_test.c
+++ b/tests/time_zone_test.c
@@ -58,7 +58,7 @@ ACU_TEST(test_atc_time_zone_zoned_extra_from_epoch_seconds_utc)
   atc_time_zone_zoned_extra_from_epoch_seconds(tz, epoch_seconds, &extra);
 
   ACU_ASSERT(! atc_zoned_extra_is_error(&extra));
-  ACU_ASSERT(extra.fold_type == kAtcFoldTypeExact);
+  ACU_ASSERT(extra.resolved == kAtcResolvedUnique);
   ACU_ASSERT(extra.std_offset_seconds == 0);
   printf("%d\n", extra.dst_offset_seconds);
   ACU_ASSERT(extra.dst_offset_seconds == 0);
@@ -76,7 +76,7 @@ ACU_TEST(test_atc_time_zone_zoned_extra_from_plain_date_time_utc)
       tz, &pdt, kAtcDisambiguateCompatible, &extra);
 
   ACU_ASSERT(! atc_zoned_extra_is_error(&extra));
-  ACU_ASSERT(extra.fold_type == kAtcFoldTypeExact);
+  ACU_ASSERT(extra.resolved == kAtcResolvedUnique);
   ACU_ASSERT(extra.std_offset_seconds == 0);
   ACU_ASSERT(extra.dst_offset_seconds == 0);
   ACU_ASSERT(extra.req_std_offset_seconds == 0);
@@ -155,7 +155,7 @@ ACU_TEST(test_atc_time_zone_zoned_extra_from_epoch_seconds_los_angeles)
   atc_time_zone_zoned_extra_from_epoch_seconds(&tz, epoch_seconds, &extra);
 
   ACU_ASSERT(! atc_zoned_extra_is_error(&extra));
-  ACU_ASSERT(extra.fold_type == kAtcFoldTypeExact);
+  ACU_ASSERT(extra.resolved == kAtcResolvedUnique);
   ACU_ASSERT(extra.std_offset_seconds == -8*3600);
   ACU_ASSERT(extra.dst_offset_seconds == 0);
   ACU_ASSERT(extra.req_std_offset_seconds == -8*3600);
@@ -175,7 +175,7 @@ ACU_TEST(test_atc_time_zone_zoned_extra_from_plain_date_time_los_angeles)
       &tz, &pdt, kAtcDisambiguateCompatible, &extra);
 
   ACU_ASSERT(! atc_zoned_extra_is_error(&extra));
-  ACU_ASSERT(extra.fold_type == kAtcFoldTypeExact);
+  ACU_ASSERT(extra.resolved == kAtcResolvedUnique);
   ACU_ASSERT(extra.std_offset_seconds == -8*3600);
   ACU_ASSERT(extra.dst_offset_seconds == 0);
   ACU_ASSERT(extra.req_std_offset_seconds == -8*3600);


### PR DESCRIPTION
- 0.15.0 (2025-11-17, TZDB 2025b)
    - **Breaking** Replace `AtcZonedExtra.fold_type` with
      `AtcZonedExtra.resolved` which is identical to
      `AtcZonedDateTime.resolved`.
